### PR TITLE
Fix N+1 problem, on querying accounts with trustlines

### DIFF
--- a/dataloader/trustlineloader.go
+++ b/dataloader/trustlineloader.go
@@ -2,14 +2,15 @@ package dataloader
 
 import (
 	"context"
-	"database/sql"
 	"github.com/mobius-network/astrograph/db"
 	"github.com/mobius-network/astrograph/model"
 	"net/http"
 	"time"
 )
 
-func TustlineLoaderMiddleware(db *sql.DB, next http.Handler) http.Handler {
+const TrustlineLoaderKey = "trustlineloader"
+
+func TrustlineLoaderMiddleware(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		trustlineLoader := TrustlineLoader{
 			maxBatch: 100,
@@ -28,7 +29,7 @@ func TustlineLoaderMiddleware(db *sql.DB, next http.Handler) http.Handler {
 				return rh, nil
 			},
 		}
-		ctx := context.WithValue(r.Context(), trustlineLoaderKey, &trustlineLoader)
+		ctx := context.WithValue(r.Context(), TrustlineLoaderKey, &trustlineLoader)
 		r = r.WithContext(ctx)
 		next.ServeHTTP(w, r)
 	})


### PR DESCRIPTION
After this patch, query
```
{
  Accounts(id: ["GCJYXHZFOT673V4UIRMZWKPWWWXL36UGAG7G4VYYJEWQOLM4K6VJLHIX", "GCWY6QG4W55XYS3K6X7R7RAQIEKZFEQXSRHU5UKCA7AHCGT5YL4FU4JY", "GC2PDSGZRZJ66H2F5TO7BGF6AZ5VQJZMTDWBQHKJX52FDH7TYW4CEMBP"]) {
    id
    balance
    trustlines {
      balance
      assetcode
      issuer
    }
  }
}
```

produces this output in logs:
 
```
astrograph --database-url="postgres://localhost/stellar_core?sslmode=disable" --debug --ingest-timeout=60
2018/06/13 11:42:24 > SELECT ledgerseq FROM ledgerheaders ORDER BY ledgerseq DESC LIMIT 1 []
2018/06/13 11:42:24 . took: 13.903773ms
2018/06/13 11:42:24 Stellar GraphQL Server
2018/06/13 11:42:24 Listening on 127.0.0.1:8000
2018/06/13 11:42:24 Current ledger sequence number: 9472245
2018/06/13 11:42:24 Ingest every 60 seconds
2018/06/13 11:42:27 >
    SELECT
      accountid,
      balance,
      seqnum,
      numsubentries,
      inflationdest,
      homedomain,
      thresholds,
      flags,
      lastmodified
    FROM accounts
    WHERE accountid
   IN('GCJYXHZFOT673V4UIRMZWKPWWWXL36UGAG7G4VYYJEWQOLM4K6VJLHIX', 'GCWY6QG4W55XYS3K6X7R7RAQIEKZFEQXSRHU5UKCA7AHCGT5YL4FU4JY', 'GC2PDSGZRZJ66H2F5TO7BGF6AZ5VQJZMTDWBQHKJX52FDH7TYW4CEMBP') []
2018/06/13 11:42:27 . took: 1.868314ms
2018/06/13 11:42:27 >
    SELECT
      accountid,
      assettype,
      issuer,
      assetcode,
      tlimit,
      balance,
      flags,
      lastmodified
    FROM trustlines
    WHERE accountid
   IN('GCJYXHZFOT673V4UIRMZWKPWWWXL36UGAG7G4VYYJEWQOLM4K6VJLHIX', 'GCWY6QG4W55XYS3K6X7R7RAQIEKZFEQXSRHU5UKCA7AHCGT5YL4FU4JY', 'GC2PDSGZRZJ66H2F5TO7BGF6AZ5VQJZMTDWBQHKJX52FDH7TYW4CEMBP') ORDER BY accountid, assettype, assetcode []
2018/06/13 11:42:27 . took: 2.29659ms
```

I guess, it means, that problem is solved? :)