### PR TITLE
Return null for non-existent account queries

### DIFF
--- a/src/repo/accounts.ts
+++ b/src/repo/accounts.ts
@@ -15,8 +15,8 @@ export default class AccountsRepo {
   }
 
   // Tries to find a transaction by id;
-  public findByID(id: string): Promise<Account> {
-    return this.db.oneOrNone(sql.selectAccount, id, res => new Account(res));
+  public findByID(id: string): Promise<Account | null> {
+    return this.db.oneOrNone(sql.selectAccount, id, res => (res ? new Account(res) : null));
   }
 
   public async findAllByIDs(ids: string[]): Promise<Array<Account | null>> {

--- a/src/schema/type_defs.ts
+++ b/src/schema/type_defs.ts
@@ -129,7 +129,7 @@ export default gql`
   }
 
   type Query {
-    account(id: AccountID!): Account!
+    account(id: AccountID!): Account
     accounts(id: [AccountID!]): [Account]
     dataEntries(id: AccountID!): [DataEntry]
     signers(id: AccountID!): [Signer]


### PR DESCRIPTION
Resolve #20 

Quick fix for querying non-existent accounts. Now it returns null for the single account query and array with nulls for the batch query. I'm not sure that's a good idea though. Maybe we should respond with an array of only existent accounts, without nulls. Or we should return some errors payload with info about missing entities besides data