### PR TITLE
Improve bulk exporter

### DIFF
--- a/src/export.ts
+++ b/src/export.ts
@@ -1,10 +1,10 @@
 import fs from "fs";
 import ProgressBar from "progress";
-import zlib  from "zlib";
-import { Ingestor } from "./storage/ingestor";
-
+import zlib from "zlib";
 import { configure, IConfig } from "./export/configure";
 import iterate from "./export/iterate";
+import { Ingestor } from "./storage/ingestor";
+import { SCHEMA } from "./storage/schema";
 import logger from "./util/logger";
 
 import { LedgerHeader, TransactionWithXDR } from "./model";
@@ -50,6 +50,8 @@ configure()
     });
 
     file.end();
+
+    fs.writeFileSync(`${config.dirPath}/export.schema`, SCHEMA.replace(/^\s*\n/gm, "").replace(/^\s\s/gm, ""));
   })
   .catch(err => {
     logger.error(err);

--- a/src/export.ts
+++ b/src/export.ts
@@ -1,4 +1,6 @@
+import fs from "fs";
 import ProgressBar from "progress";
+import zlib  from "zlib";
 import { Ingestor } from "./storage/ingestor";
 
 import { configure, IConfig } from "./export/configure";
@@ -9,16 +11,46 @@ import { LedgerHeader, TransactionWithXDR } from "./model";
 
 logger.info("DGraph live export script, yarn export <count> <seq>");
 
-configure().then(async (config: IConfig) => {
-  const bar = new ProgressBar("[:bar] :elapseds elapsed, eta :etas", { total: config.total });
+configure()
+  .then(async (config: IConfig) => {
+    const bar = new ProgressBar("[:bar] :elapseds elapsed, eta :etas", { total: config.total });
 
-  logger.info(`Exporting ${config.total} ledgers ${config.minSeq}/${config.maxSeq}`);
+    logger.info(`Exporting ${config.total} ledgers ${config.minSeq}/${config.maxSeq}`);
 
-  await iterate(config.minSeq, config.maxSeq, async (header: LedgerHeader, transactions: TransactionWithXDR[]) => {
-    const chunk = await Ingestor.ingestLedger(header, transactions);
-    config.file.write(chunk.toString() + "\n");
-    bar.tick();
+    const buildSliceFileName = (sliceNum: number) => {
+      const { minSeq, maxSeq, sliceSize } = config;
+      const sliceStart = minSeq + sliceNum * sliceSize;
+      let sliceEnd = minSeq + (sliceNum + 1) * sliceSize - 1;
+
+      if (sliceEnd > maxSeq) {
+        sliceEnd = maxSeq;
+      }
+
+      return `${config.dirPath}/${sliceStart}-${sliceEnd}.rdf.gz`;
+    };
+
+    let ledgerCounter = 0;
+    let sliceCounter = -1;
+    let file = zlib.createGzip();
+
+    await iterate(config.minSeq, config.maxSeq, async (header: LedgerHeader, transactions: TransactionWithXDR[]) => {
+      if (ledgerCounter % config.sliceSize === 0) {
+        file.end();
+        file = zlib.createGzip();
+
+        sliceCounter += 1;
+        file.pipe(fs.createWriteStream(buildSliceFileName(sliceCounter)));
+      }
+
+      const chunk = await Ingestor.ingestLedger(header, transactions);
+      file.write(chunk.toString() + "\n");
+
+      ledgerCounter += 1;
+      bar.tick();
+    });
+
+    file.end();
+  })
+  .catch(err => {
+    logger.error(err);
   });
-
-  config.file.end();
-});


### PR DESCRIPTION
Resolve #117 

- [x] for every export use a subfolder inside the base export directory
- [x] use .rdf.gz instead of .nquads.gz
- [x] auto-split a range of ledgers into chunks (10k ledgers per chunk sounds reasonable), every chunk goes into separate ".gz" file
- [x]  dump the schema of exported data into export.schema file in Dgraph schema format

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/astroband/astrograph/119)
<!-- Reviewable:end -->
