### PR TITLE
Enter "trades"

### DIFF
--- a/src/model/factories/operations_data_mapper.ts
+++ b/src/model/factories/operations_data_mapper.ts
@@ -26,7 +26,7 @@ export class DataMapper {
   constructor(private data: DgraphOperationsData) {
     this.baseData = {
       kind: data.kind,
-      account: data["account.source"][0].id,
+      account: data["account.source"][0]["account.id"],
       index: parseInt(data.index, 10),
       dateTime: new Date(data.ledger[0].close_time),
       transactionId: data.transaction[0].id
@@ -61,13 +61,13 @@ export class DataMapper {
 
   private mapPayment(): IPaymentOperation {
     const assetData = this.data.asset[0];
-    const asset = assetData.native ? Asset.native() : new Asset(assetData.code, assetData.issuer[0].id);
+    const asset = assetData.native ? Asset.native() : new Asset(assetData.code, assetData.issuer[0]["account.id"]);
 
     return {
       ...this.baseData,
       ...{
-        destination: this.data["account.destination"][0].id,
-        source: this.data["account.source"][0].id,
+        destination: this.data["account.destination"][0]["account.id"],
+        source: this.data["account.source"][0]["account.id"],
         amount: this.data.amount,
         asset
       }
@@ -78,7 +78,7 @@ export class DataMapper {
     return {
       ...this.baseData,
       ...{
-        destination: this.data["account.destination"][0].id
+        destination: this.data["account.destination"][0]["account.id"]
       }
     };
   }
@@ -99,9 +99,9 @@ export class DataMapper {
           medium: parseInt(this.data.thresholds[0].med, 10),
           low: parseInt(this.data.thresholds[0].low, 10)
         },
-        inflationDestination: this.data["account.inflation_dest"][0].id,
+        inflationDestination: this.data["account.inflation_dest"][0]["account.id"],
         signer: {
-          account: this.data.signer[0].account[0].id,
+          account: this.data.signer[0].account[0]["account.id"],
           weight: parseInt(this.data.signer[0].weight, 10)
         }
       }
@@ -112,7 +112,7 @@ export class DataMapper {
     return {
       ...this.baseData,
       ...{
-        trustor: this.data.trustor[0].id,
+        trustor: this.data.trustor[0]["account.id"],
         authorize: this.data.authorize,
         assetCode: this.data.asset_code
       }
@@ -127,7 +127,7 @@ export class DataMapper {
   }
 
   private mapChangeTrust(): IChangeTrustOperation {
-    const asset = new Asset(this.data.asset[0].code, this.data.asset[0].issuer[0].id);
+    const asset = new Asset(this.data.asset[0].code, this.data.asset[0].issuer[0]["account.id"]);
 
     return {
       ...this.baseData,
@@ -140,7 +140,7 @@ export class DataMapper {
       ...this.baseData,
       ...{
         startingBalance: this.data.starting_balance,
-        destination: this.data["account.destination"][0].id
+        destination: this.data["account.destination"][0]["account.id"]
       }
     };
   }
@@ -158,10 +158,10 @@ export class DataMapper {
 
     const assetBuying = assetBuyingData.native
       ? Asset.native()
-      : new Asset(assetBuyingData.code, assetBuyingData.issuer[0].id);
+      : new Asset(assetBuyingData.code, assetBuyingData.issuer[0]["account.id"]);
     const assetSelling = assetSellingData.native
       ? Asset.native()
-      : new Asset(assetSellingData.code, assetSellingData.issuer[0].id);
+      : new Asset(assetSellingData.code, assetSellingData.issuer[0]["account.id"]);
 
     return {
       ...this.baseData,
@@ -185,22 +185,22 @@ export class DataMapper {
 
     const destinationAsset = destinationAssetData.native
       ? Asset.native()
-      : new Asset(destinationAssetData.code, destinationAssetData.issuer[0].id);
+      : new Asset(destinationAssetData.code, destinationAssetData.issuer[0]["account.id"]);
     const sourceAsset = sourceAssetData.native
       ? Asset.native()
-      : new Asset(sourceAssetData.code, sourceAssetData.issuer[0].id);
+      : new Asset(sourceAssetData.code, sourceAssetData.issuer[0]["account.id"]);
 
     return {
       ...this.baseData,
       ...{
         sendMax: this.data.send_max,
         destinationAmount: this.data.dest_amount,
-        destinationAccount: this.data["account.destination"][0].id,
+        destinationAccount: this.data["account.destination"][0]["account.id"],
         destinationAsset,
-        sourceAccount: this.data["account.source"][0].id,
+        sourceAccount: this.data["account.source"][0]["account.id"],
         sourceAsset,
         path: this.data["assets.path"].map((assetData: IAssetData) => {
-          return assetData.native ? Asset.native() : new Asset(assetData.code, assetData.issuer[0].id);
+          return assetData.native ? Asset.native() : new Asset(assetData.code, assetData.issuer[0]["account.id"]);
         })
       }
     };

--- a/src/model/factories/operations_data_mapper.ts
+++ b/src/model/factories/operations_data_mapper.ts
@@ -202,7 +202,7 @@ export class DataMapper {
       ...this.baseData,
       ...{
         sendMax: this.data.send_max,
-        destinationAmount: this.data.dest_amount,
+        destinationAmount: this.data.amount,
         destinationAccount: this.data["op.destination"][0]["account.id"],
         destinationAsset,
         sourceAccount: this.data["op.source"][0]["account.id"],

--- a/src/model/factories/operations_data_mapper.ts
+++ b/src/model/factories/operations_data_mapper.ts
@@ -61,7 +61,9 @@ export class DataMapper {
 
   private mapPayment(): IPaymentOperation {
     const assetData = this.data.asset[0];
-    const asset = assetData.native ? Asset.native() : new Asset(assetData.code, assetData.issuer[0]["account.id"]);
+    const asset = assetData.native
+      ? Asset.native()
+      : new Asset(assetData.code, assetData["asset.issuer"][0]["account.id"]);
 
     return {
       ...this.baseData,
@@ -127,7 +129,7 @@ export class DataMapper {
   }
 
   private mapChangeTrust(): IChangeTrustOperation {
-    const asset = new Asset(this.data.asset[0].code, this.data.asset[0].issuer[0]["account.id"]);
+    const asset = new Asset(this.data.asset[0].code, this.data.asset[0]["asset.issuer"][0]["account.id"]);
 
     return {
       ...this.baseData,
@@ -158,10 +160,10 @@ export class DataMapper {
 
     const assetBuying = assetBuyingData.native
       ? Asset.native()
-      : new Asset(assetBuyingData.code, assetBuyingData.issuer[0]["account.id"]);
+      : new Asset(assetBuyingData.code, assetBuyingData["asset.issuer"][0]["account.id"]);
     const assetSelling = assetSellingData.native
       ? Asset.native()
-      : new Asset(assetSellingData.code, assetSellingData.issuer[0]["account.id"]);
+      : new Asset(assetSellingData.code, assetSellingData["asset.issuer"][0]["account.id"]);
 
     return {
       ...this.baseData,
@@ -185,10 +187,10 @@ export class DataMapper {
 
     const destinationAsset = destinationAssetData.native
       ? Asset.native()
-      : new Asset(destinationAssetData.code, destinationAssetData.issuer[0]["account.id"]);
+      : new Asset(destinationAssetData.code, destinationAssetData["asset.issuer"][0]["account.id"]);
     const sourceAsset = sourceAssetData.native
       ? Asset.native()
-      : new Asset(sourceAssetData.code, sourceAssetData.issuer[0]["account.id"]);
+      : new Asset(sourceAssetData.code, sourceAssetData["asset.issuer"][0]["account.id"]);
 
     return {
       ...this.baseData,
@@ -200,7 +202,9 @@ export class DataMapper {
         sourceAccount: this.data["account.source"][0]["account.id"],
         sourceAsset,
         path: this.data["assets.path"].map((assetData: IAssetData) => {
-          return assetData.native ? Asset.native() : new Asset(assetData.code, assetData.issuer[0]["account.id"]);
+          return assetData.native
+            ? Asset.native()
+            : new Asset(assetData.code, assetData["asset.issuer"][0]["account.id"]);
         })
       }
     };

--- a/src/model/factories/transaction_factory.ts
+++ b/src/model/factories/transaction_factory.ts
@@ -24,7 +24,7 @@ export class TransactionFactory {
       feeCharged: node.fee_charged,
       success: node.success,
       resultCode: node.result_code,
-      sourceAccount: node["account.source"][0].id,
+      sourceAccount: node["account.source"][0]["account.id"],
       timeBounds
     });
   }

--- a/src/model/factories/transaction_factory.ts
+++ b/src/model/factories/transaction_factory.ts
@@ -16,15 +16,15 @@ export class TransactionFactory {
     };
 
     return new Transaction({
-      id: node.id,
-      ledgerSeq: parseInt(node.seq, 10),
-      index: parseInt(node.index, 10),
+      id: node["tx.id"],
+      ledgerSeq: parseInt(node["tx.ledger"][0]["ledger.id"], 10),
+      index: parseInt(node["tx.index"], 10),
       memo,
       feeAmount: node.fee_amount,
       feeCharged: node.fee_charged,
       success: node.success,
       resultCode: node.result_code,
-      sourceAccount: node["account.source"][0]["account.id"],
+      sourceAccount: node["tx.source"][0]["account.id"],
       timeBounds
     });
   }

--- a/src/model/operation.ts
+++ b/src/model/operation.ts
@@ -3,7 +3,6 @@
 // of data that is stored in Dgraph
 import { AccountID } from "./account_id";
 import { Asset } from "./asset";
-import { AssetCode } from "./asset_code";
 
 export enum OperationKinds {
   Payment = "payment",
@@ -55,7 +54,7 @@ export interface IAccountMergeOperation extends IBaseOperation {
 }
 
 export interface IAllowTrustOperation extends IBaseOperation {
-  assetCode: AssetCode;
+  asset: Asset;
   trustor: AccountID;
   authorize: boolean;
 }

--- a/src/storage/builders/account.ts
+++ b/src/storage/builders/account.ts
@@ -21,10 +21,10 @@ export class AccountBuilder extends Builder {
 
   public build(): NQuads {
     this.pushKey();
-    this.pushValue("type.account", "");
-    this.pushValue("type", "account");
-    this.pushValue("id", this.id);
-    this.pushValue("deleted", false);
+    this.pushValues({
+      "account.id": this.id,
+      deleted: false
+    });
 
     return this.nquads;
   }

--- a/src/storage/builders/asset.ts
+++ b/src/storage/builders/asset.ts
@@ -27,13 +27,11 @@ export class AssetBuilder extends Builder {
 
     this.pushKey();
 
-    this.pushValue("type.asset", "");
-    this.pushValue("type", "asset");
-    this.pushValue("native", this.asset.isNative().toString());
-    this.pushValue("code", code);
     this.pushValue("asset.id", `${code}-${issuer}`);
+    this.pushValue("code", code);
+    this.pushValue("native", this.asset.isNative().toString());
 
-    this.pushBuilder(new AccountBuilder(issuer), "issuer", "assets.issued");
+    this.pushBuilder(new AccountBuilder(issuer), "asset.issuer");
 
     return this.nquads;
   }

--- a/src/storage/builders/builder.ts
+++ b/src/storage/builders/builder.ts
@@ -35,11 +35,13 @@ export abstract class Builder {
     this.pushValue("key", this.current.value);
   }
 
-  protected pushPrev() {
-    if (this.prev) {
-      this.nquads.push(new NQuad(this.current, "prev", this.prev));
-      this.nquads.push(new NQuad(this.prev, "next", this.current));
+  protected pushPrev(predicatePrefix?: string) {
+    if (!this.prev) {
+      return
     }
+
+    const predicate = predicatePrefix ? `${predicatePrefix}.prev` : "prev";
+    this.nquads.push(new NQuad(this.current, predicate, this.prev));
   }
 
   protected pushLedger(seq: number) {

--- a/src/storage/builders/builder.ts
+++ b/src/storage/builders/builder.ts
@@ -37,7 +37,7 @@ export abstract class Builder {
 
   protected pushPrev(predicatePrefix?: string) {
     if (!this.prev) {
-      return
+      return;
     }
 
     const predicate = predicatePrefix ? `${predicatePrefix}.prev` : "prev";

--- a/src/storage/builders/builder.ts
+++ b/src/storage/builders/builder.ts
@@ -44,8 +44,9 @@ export abstract class Builder {
     this.nquads.push(new NQuad(this.current, predicate, this.prev));
   }
 
-  protected pushLedger(seq: number) {
-    this.nquads.push(new NQuad(this.current, "ledger", LedgerBuilder.keyNQuad(seq)));
+  protected pushLedger(seq: number, predicatePrefix?: string) {
+    const predicate = predicatePrefix ? `${predicatePrefix}.ledger` : "ledger";
+    this.nquads.push(new NQuad(this.current, predicate, LedgerBuilder.keyNQuad(seq)));
   }
 
   protected pushBuilder(builder: Builder, key?: string, foreignKey?: string) {

--- a/src/storage/builders/index.ts
+++ b/src/storage/builders/index.ts
@@ -6,5 +6,6 @@ export * from "./path_payment_result";
 export * from "./account";
 export * from "./asset";
 export * from "./ledger_state";
+export * from "./trade";
 export * from "./transaction";
 export * from "./trust_line_entry";

--- a/src/storage/builders/ledger.ts
+++ b/src/storage/builders/ledger.ts
@@ -25,9 +25,7 @@ export class LedgerBuilder extends Builder {
 
   public build(): NQuads {
     const values = {
-      "type.ledger": "",
-      type: "ledger",
-      seq: this.seq,
+      "ledger.id": this.seq,
       order: this.order(this.seq),
       version: this.header.ledgerVersion,
       base_fee: this.header.baseFee,
@@ -37,7 +35,7 @@ export class LedgerBuilder extends Builder {
     };
 
     this.pushKey();
-    this.pushPrev();
+    this.pushPrev("ledger");
     this.pushValues(values);
 
     return this.nquads;

--- a/src/storage/builders/ledger_state.ts
+++ b/src/storage/builders/ledger_state.ts
@@ -1,4 +1,4 @@
-import { IChange } from "../../changes_extractor";
+import { ChangeType, EntryType, IChange } from "../../changes_extractor";
 import { ITransaction, ITrustLineBase } from "../../model";
 import { TrustLineValuesFactory } from "../../model/factories/trust_line_values_factory";
 import { NQuad, NQuads } from "../nquads";
@@ -21,10 +21,10 @@ export class LedgerStateBuilder {
 
     this.changes.forEach((change, i) => {
       switch (change.type) {
-        case "created":
+        case ChangeType.Created:
           builder = this.buildCreatedBuilder(change, i);
           break;
-        case "updated":
+        case ChangeType.Updated:
           builder = this.buildUpdatedBuilder(change, i);
           break;
         default:
@@ -45,10 +45,10 @@ export class LedgerStateBuilder {
     let data: ITrustLineBase;
 
     switch (change.entry) {
-      case "account":
+      case EntryType.Account:
         data = TrustLineValuesFactory.fakeNativeFromXDR(change.data.account());
         break;
-      case "trustline":
+      case EntryType.Trustline:
         data = TrustLineValuesFactory.fromXDR(change.data.trustLine());
         break;
       default:
@@ -63,13 +63,13 @@ export class LedgerStateBuilder {
     let data: ITrustLineBase;
 
     switch (change.entry) {
-      case "account":
+      case EntryType.Account:
         if (change.accountChanges && !change.accountChanges.includes("balance")) {
           return null;
         }
         data = TrustLineValuesFactory.fakeNativeFromXDR(change.data.account());
         break;
-      case "trustline":
+      case EntryType.Trustline:
         data = TrustLineValuesFactory.fromXDR(change.data.trustLine());
         break;
       default:

--- a/src/storage/builders/operation.ts
+++ b/src/storage/builders/operation.ts
@@ -68,14 +68,9 @@ export class OperationBuilder extends Builder {
       case t.payment():
         return new PaymentOpBuilder(this.current, this.xdr.body().paymentOp(), this.resultXDR);
       case t.pathPayment():
-        return new PathPaymentOpBuilder(this.current, this.xdr.body().pathPaymentOp(), this.resultXDR, [
-          "operation",
-          this.tx.ledgerSeq,
-          this.index,
-          this.n
-        ]);
+        return new PathPaymentOpBuilder(this.current, this.xdr.body().pathPaymentOp(), this.resultXDR);
       case t.manageOffer():
-        return new ManageOfferOpBuilder(this.current, this.xdr.body().manageOfferOp());
+        return new ManageOfferOpBuilder(this.current, this.xdr.body().manageOfferOp(), this.resultXDR);
       case t.setOption():
         return new SetOptionsOpBuilder(this.current, this.xdr.body().setOptionsOp(), this.resultXDR);
       case t.changeTrust():
@@ -115,7 +110,6 @@ export class OperationBuilder extends Builder {
 
     this.pushValues(values);
     this.pushLedger(this.seq, "op");
-    this.pushResult();
 
     this.nquads.push(new NQuad(this.current, "op.transaction", tx));
     this.pushBuilder(new AccountBuilder(this.sourceAccount()), "op.source");
@@ -127,14 +121,5 @@ export class OperationBuilder extends Builder {
       return publicKeyFromBuffer(account.value());
     }
     return this.tx.sourceAccount;
-  }
-
-  private pushResult() {
-    if (!this.resultXDR) {
-      return;
-    }
-
-    this.pushValue("result_code", this.resultXDR.switch().value);
-    this.pushValue("success", this.resultXDR.switch() === stellar.xdr.OperationResultCode.opInner());
   }
 }

--- a/src/storage/builders/operation.ts
+++ b/src/storage/builders/operation.ts
@@ -70,7 +70,12 @@ export class OperationBuilder extends Builder {
       case t.pathPayment():
         return new PathPaymentOpBuilder(this.current, this.xdr.body().pathPaymentOp(), this.resultXDR);
       case t.manageOffer():
-        return new ManageOfferOpBuilder(this.current, this.xdr.body().manageOfferOp(), this.resultXDR);
+        return new ManageOfferOpBuilder(
+          this.current,
+          this.xdr.body().manageOfferOp(),
+          this.sourceAccount(),
+          this.resultXDR
+        );
       case t.setOption():
         return new SetOptionsOpBuilder(this.current, this.xdr.body().setOptionsOp(), this.resultXDR);
       case t.changeTrust():

--- a/src/storage/builders/operations/account_merge_op.ts
+++ b/src/storage/builders/operations/account_merge_op.ts
@@ -6,11 +6,7 @@ export class AccountMergeOpBuilder extends SpecificOperationBuilder {
   public build(): NQuads {
     super.build();
 
-    this.pushBuilder(
-      new AccountBuilder(publicKeyFromBuffer(this.xdr.destination().value())),
-      "account.destination",
-      "operations"
-    );
+    this.pushBuilder(new AccountBuilder(publicKeyFromBuffer(this.xdr.destination().value())), "op.destination");
 
     return this.nquads;
   }
@@ -18,7 +14,7 @@ export class AccountMergeOpBuilder extends SpecificOperationBuilder {
   protected pushResult() {
     const result = this.trXDR.accountMergeResult();
     const resultCode = result.switch().value;
-    this.pushValue("account_merge_result_code", resultCode);
+    this.pushValue("account_merge_op.result_code", resultCode);
 
     // if not success
     if (resultCode !== 0) {

--- a/src/storage/builders/operations/account_merge_op.ts
+++ b/src/storage/builders/operations/account_merge_op.ts
@@ -1,6 +1,6 @@
 import { AccountBuilder, SpecificOperationBuilder } from "../";
 import { publicKeyFromBuffer } from "../../../util/xdr/account";
-import { NQuad, NQuads } from "../../nquads";
+import { NQuads } from "../../nquads";
 
 export class AccountMergeOpBuilder extends SpecificOperationBuilder {
   public build(): NQuads {
@@ -11,22 +11,11 @@ export class AccountMergeOpBuilder extends SpecificOperationBuilder {
     return this.nquads;
   }
 
-  protected pushResult() {
-    const result = this.trXDR.accountMergeResult();
-    const resultCode = result.switch().value;
-    this.pushValue("account_merge_op.result_code", resultCode);
-
-    // if not success
-    if (resultCode !== 0) {
+  protected get resultCode() {
+    if (!this.trXDR) {
       return;
     }
 
-    const resultNQuad = NQuad.blank(`${this.current.value}_result`);
-
-    this.nquads.push(
-      new NQuad(resultNQuad, "source_account_balance", NQuad.value(result.sourceAccountBalance().toString()))
-    );
-
-    this.nquads.push(new NQuad(this.current, "result", resultNQuad));
+    return this.trXDR.accountMergeResult().switch().value;
   }
 }

--- a/src/storage/builders/operations/allow_trust_op.ts
+++ b/src/storage/builders/operations/allow_trust_op.ts
@@ -1,8 +1,19 @@
-import { AccountBuilder, SpecificOperationBuilder } from "../";
+import { Asset } from "stellar-sdk";
+import { AccountBuilder, AssetBuilder, SpecificOperationBuilder } from "../";
 import { publicKeyFromBuffer } from "../../../util/xdr/account";
-import { NQuads } from "../../nquads";
+import { IBlank, NQuads } from "../../nquads";
 
 export class AllowTrustOpBuilder extends SpecificOperationBuilder {
+  // FIXME: adding `source` only for this operation is a dirty hack
+  constructor(
+    public readonly current: IBlank,
+    public readonly source: string,
+    protected xdr: any,
+    protected resultXDR: any
+  ) {
+    super(current, xdr, resultXDR);
+  }
+
   public build(): NQuads {
     super.build();
 
@@ -12,9 +23,10 @@ export class AllowTrustOpBuilder extends SpecificOperationBuilder {
       .value()
       .toString()
       .replace(/\0/g, "");
+    const asset = new Asset(assetCode, this.source);
 
-    this.pushBuilder(new AccountBuilder(id), "trustor", "operations");
-    this.pushValue("asset_code", assetCode);
+    this.pushBuilder(new AccountBuilder(id), "allow_trust_op.trustor");
+    this.pushBuilder(new AssetBuilder(asset), "allow_trust_op.asset", "operations");
     this.pushValue("authorize", this.xdr.authorize());
 
     return this.nquads;
@@ -22,6 +34,6 @@ export class AllowTrustOpBuilder extends SpecificOperationBuilder {
 
   protected pushResult() {
     const code = this.trXDR.allowTrustResult().switch().value;
-    this.pushValue("allow_trust_result_code", code);
+    this.pushValue("allow_trust_op.result_code", code);
   }
 }

--- a/src/storage/builders/operations/allow_trust_op.ts
+++ b/src/storage/builders/operations/allow_trust_op.ts
@@ -7,8 +7,8 @@ export class AllowTrustOpBuilder extends SpecificOperationBuilder {
   // FIXME: adding `source` only for this operation is a dirty hack
   constructor(
     public readonly current: IBlank,
-    public readonly source: string,
     protected xdr: any,
+    public readonly source: string,
     protected resultXDR: any
   ) {
     super(current, xdr, resultXDR);

--- a/src/storage/builders/operations/allow_trust_op.ts
+++ b/src/storage/builders/operations/allow_trust_op.ts
@@ -32,8 +32,11 @@ export class AllowTrustOpBuilder extends SpecificOperationBuilder {
     return this.nquads;
   }
 
-  protected pushResult() {
-    const code = this.trXDR.allowTrustResult().switch().value;
-    this.pushValue("allow_trust_op.result_code", code);
+  protected get resultCode() {
+    if (!this.trXDR) {
+      return;
+    }
+
+    return this.trXDR.allowTrustResult().switch().value;
   }
 }

--- a/src/storage/builders/operations/bump_sequence_op.ts
+++ b/src/storage/builders/operations/bump_sequence_op.ts
@@ -10,8 +10,11 @@ export class BumpSequenceOpBuilder extends SpecificOperationBuilder {
     return this.nquads;
   }
 
-  protected pushResult() {
-    const code = this.trXDR.bumpSeqResult().switch().value;
-    this.pushValue("bump_sequence_op.result_code", code);
+  protected get resultCode() {
+    if (!this.trXDR) {
+      return;
+    }
+
+    return this.trXDR.bumpSeqResult().switch().value;
   }
 }

--- a/src/storage/builders/operations/bump_sequence_op.ts
+++ b/src/storage/builders/operations/bump_sequence_op.ts
@@ -12,6 +12,6 @@ export class BumpSequenceOpBuilder extends SpecificOperationBuilder {
 
   protected pushResult() {
     const code = this.trXDR.bumpSeqResult().switch().value;
-    this.pushValue("bump_sequence_result_code", code);
+    this.pushValue("bump_sequence_op.result_code", code);
   }
 }

--- a/src/storage/builders/operations/change_trust_op.ts
+++ b/src/storage/builders/operations/change_trust_op.ts
@@ -9,13 +9,13 @@ export class ChangeTrustOpBuilder extends SpecificOperationBuilder {
     this.pushValue("limit", this.xdr.limit().toString());
 
     const asset = Asset.fromOperation(this.xdr.line());
-    this.pushBuilder(new AssetBuilder(asset), "asset", "operations");
+    this.pushBuilder(new AssetBuilder(asset), "change_trust_op.asset");
 
     return this.nquads;
   }
 
   protected pushResult() {
     const code = this.trXDR.changeTrustResult().switch().value;
-    this.pushValue("change_trust_result_code", code);
+    this.pushValue("change_trust.result_code", code);
   }
 }

--- a/src/storage/builders/operations/change_trust_op.ts
+++ b/src/storage/builders/operations/change_trust_op.ts
@@ -14,8 +14,11 @@ export class ChangeTrustOpBuilder extends SpecificOperationBuilder {
     return this.nquads;
   }
 
-  protected pushResult() {
-    const code = this.trXDR.changeTrustResult().switch().value;
-    this.pushValue("change_trust.result_code", code);
+  protected get resultCode() {
+    if (!this.trXDR) {
+      return;
+    }
+
+    return this.trXDR.changeTrustResult().switch().value;
   }
 }

--- a/src/storage/builders/operations/create_account_op.ts
+++ b/src/storage/builders/operations/create_account_op.ts
@@ -10,7 +10,7 @@ export class CreateAccountOpBuilder extends SpecificOperationBuilder {
     const destination = publicKeyFromBuffer(this.xdr.destination().value());
 
     this.pushValue("starting_balance", startingBalance);
-    this.pushBuilder(new AccountBuilder(destination), "account.destination", "operations");
+    this.pushBuilder(new AccountBuilder(destination), "account.destination");
 
     return this.nquads;
   }
@@ -18,5 +18,13 @@ export class CreateAccountOpBuilder extends SpecificOperationBuilder {
   protected pushResult() {
     const code = this.trXDR.createAccountResult().switch().value;
     this.pushValue("create_account_result_code", code);
+  }
+
+  protected get resultCode() {
+    if (!this.trXDR) {
+      return;
+    }
+
+    return this.trXDR.createAccountResult().switch().value;
   }
 }

--- a/src/storage/builders/operations/manage_data_op.ts
+++ b/src/storage/builders/operations/manage_data_op.ts
@@ -13,8 +13,11 @@ export class ManageDataOpBuilder extends SpecificOperationBuilder {
     return this.nquads;
   }
 
-  protected pushResult() {
-    const code = this.trXDR.manageDataResult().switch().value;
-    this.pushValue("manage_data.result_code", code);
+  protected get resultCode() {
+    if (!this.trXDR) {
+      return;
+    }
+
+    return this.trXDR.manageDataResult().switch().value;
   }
 }

--- a/src/storage/builders/operations/manage_data_op.ts
+++ b/src/storage/builders/operations/manage_data_op.ts
@@ -15,6 +15,6 @@ export class ManageDataOpBuilder extends SpecificOperationBuilder {
 
   protected pushResult() {
     const code = this.trXDR.manageDataResult().switch().value;
-    this.pushValue("manage_data_result_code", code);
+    this.pushValue("manage_data.result_code", code);
   }
 }

--- a/src/storage/builders/operations/manage_offer_op.ts
+++ b/src/storage/builders/operations/manage_offer_op.ts
@@ -1,13 +1,9 @@
 import BigNumber from "bignumber.js";
 import { Asset } from "stellar-sdk";
-import { AssetBuilder, Builder } from "../";
-import { IBlank, NQuads } from "../../nquads";
+import { AssetBuilder, SpecificOperationBuilder } from "../";
+import { NQuads } from "../../nquads";
 
-export class ManageOfferOpBuilder extends Builder {
-  constructor(public readonly current: IBlank, private xdr: any) {
-    super();
-  }
-
+export class ManageOfferOpBuilder extends SpecificOperationBuilder {
   public build(): NQuads {
     const selling = Asset.fromOperation(this.xdr.selling());
     const buying = Asset.fromOperation(this.xdr.buying());
@@ -26,5 +22,13 @@ export class ManageOfferOpBuilder extends Builder {
     this.pushBuilder(new AssetBuilder(buying), "manage_offer_op.asset_buying", "operations");
 
     return this.nquads;
+  }
+
+  protected get resultCode() {
+    if (!this.trXDR) {
+      return;
+    }
+
+    return this.trXDR.manageOfferResult().switch().value;
   }
 }

--- a/src/storage/builders/operations/manage_offer_op.ts
+++ b/src/storage/builders/operations/manage_offer_op.ts
@@ -1,25 +1,50 @@
-import BigNumber from "bignumber.js";
 import { Asset } from "stellar-sdk";
-import { AssetBuilder, SpecificOperationBuilder } from "../";
-import { NQuads } from "../../nquads";
+import { SpecificOperationBuilder, TradeBuilder } from "../";
+import { publicKeyFromBuffer } from "../../../util/xdr/account";
+import { IBlank, NQuad, NQuads } from "../../nquads";
 
 export class ManageOfferOpBuilder extends SpecificOperationBuilder {
+  constructor(
+    public readonly current: IBlank,
+    protected xdr: any,
+    public readonly source: string,
+    protected resultXDR: any
+  ) {
+    super(current, xdr, resultXDR);
+  }
+
   public build(): NQuads {
-    const selling = Asset.fromOperation(this.xdr.selling());
-    const buying = Asset.fromOperation(this.xdr.buying());
-    const price = {
-      n: this.xdr.price().n(),
-      d: this.xdr.price().d()
-    };
+    const result = this.trXDR.manageOfferResult().success();
 
-    this.pushValue("price_n", price.n);
-    this.pushValue("price_d", price.d);
-    this.pushValue("price", new BigNumber(price.n).div(price.d).toString());
+    if (!result) {
+      return this.nquads;
+    }
 
-    this.pushValue("amount", this.xdr.amount().toString());
-    this.pushValue("offer_id", this.xdr.offerId().toString());
-    this.pushBuilder(new AssetBuilder(selling), "manage_offer_op.asset_selling", "operations");
-    this.pushBuilder(new AssetBuilder(buying), "manage_offer_op.asset_buying", "operations");
+    result.offersClaimed().forEach((atom: any) => {
+      const sellerId = publicKeyFromBuffer(atom.sellerId().value());
+      const offerId = atom.offerId().toInt();
+
+      const tradeBuilder1 = new TradeBuilder({
+        sellerId,
+        buyerId: this.source,
+        asset: Asset.fromOperation(atom.assetSold()),
+        amount: atom.amountSold().toInt(),
+        offerId
+      });
+
+      const tradeBuilder2 = new TradeBuilder({
+        sellerId: this.source,
+        buyerId: sellerId,
+        asset: Asset.fromOperation(atom.assetBought()),
+        amount: atom.amountBought().toInt(),
+        offerId
+      });
+
+      this.nquads.push(...tradeBuilder1.build());
+      this.nquads.push(...tradeBuilder2.build());
+      this.nquads.push(new NQuad(tradeBuilder1.current, "trade.counterpart", tradeBuilder2.current));
+      this.nquads.push(new NQuad(tradeBuilder2.current, "trade.counterpart", tradeBuilder1.current));
+    });
 
     return this.nquads;
   }

--- a/src/storage/builders/operations/manage_offer_op.ts
+++ b/src/storage/builders/operations/manage_offer_op.ts
@@ -15,7 +15,6 @@ export class ManageOfferOpBuilder extends Builder {
       n: this.xdr.price().n(),
       d: this.xdr.price().d()
     };
-    // const priceNquad = NQuad.blank(`${this.current.value}_price`);
 
     this.pushValue("price_n", price.n);
     this.pushValue("price_d", price.d);
@@ -23,8 +22,8 @@ export class ManageOfferOpBuilder extends Builder {
 
     this.pushValue("amount", this.xdr.amount().toString());
     this.pushValue("offer_id", this.xdr.offerId().toString());
-    this.pushBuilder(new AssetBuilder(selling), "asset.selling", "operations");
-    this.pushBuilder(new AssetBuilder(buying), "asset.buying", "operations");
+    this.pushBuilder(new AssetBuilder(selling), "manage_offer_op.asset_selling", "operations");
+    this.pushBuilder(new AssetBuilder(buying), "manage_offer_op.asset_buying", "operations");
 
     return this.nquads;
   }

--- a/src/storage/builders/operations/path_payment_op.ts
+++ b/src/storage/builders/operations/path_payment_op.ts
@@ -1,15 +1,7 @@
-import { AccountBuilder, AssetBuilder, PathPaymentResultBuilder, SpecificOperationBuilder } from "../";
-import { IBlank, NQuads } from "../../nquads";
+import { AccountBuilder, AssetBuilder, SpecificOperationBuilder } from "../";
+import { NQuads } from "../../nquads";
 
 export class PathPaymentOpBuilder extends SpecificOperationBuilder {
-  private baseKey: any[];
-
-  constructor(public readonly current: IBlank, protected xdr: any, protected resultXDR: any, baseKey: any[]) {
-    super(current, xdr, resultXDR);
-
-    this.baseKey = baseKey;
-  }
-
   public build(): NQuads {
     super.build();
     this.pushValue("send_max", this.xdr.sendMax().toString());
@@ -29,10 +21,12 @@ export class PathPaymentOpBuilder extends SpecificOperationBuilder {
     return this.nquads;
   }
 
-  protected pushResult() {
-    const resultBuilder = new PathPaymentResultBuilder(this.baseKey, this.trXDR.pathPaymentResult());
+  protected get resultCode() {
+    if (!this.trXDR) {
+      return;
+    }
 
-    this.pushBuilder(resultBuilder, "result");
+    return this.trXDR.pathPaymentResult().switch().value;
   }
 
   private get entityPrefix() {

--- a/src/storage/builders/operations/path_payment_op.ts
+++ b/src/storage/builders/operations/path_payment_op.ts
@@ -13,7 +13,7 @@ export class PathPaymentOpBuilder extends SpecificOperationBuilder {
   public build(): NQuads {
     super.build();
     this.pushValue("send_max", this.xdr.sendMax().toString());
-    this.pushValue("dest_amount", this.xdr.destAmount().toString());
+    this.pushValue("amount", this.xdr.destAmount().toString());
     this.pushBuilder(AccountBuilder.fromXDR(this.xdr.destination()), "op.destination");
     this.pushBuilder(
       AssetBuilder.fromXDR(this.xdr.destAsset()),

--- a/src/storage/builders/operations/path_payment_op.ts
+++ b/src/storage/builders/operations/path_payment_op.ts
@@ -23,7 +23,7 @@ export class PathPaymentOpBuilder extends SpecificOperationBuilder {
     this.pushBuilder(AssetBuilder.fromXDR(this.xdr.sendAsset()), `${this.entityPrefix}.asset_source`, "operations");
 
     (this.xdr.path() as any[]).forEach(xdr => {
-      this.pushBuilder(AssetBuilder.fromXDR(xdr), "assets.path", "operations");
+      this.pushBuilder(AssetBuilder.fromXDR(xdr), "path_payment_op.assets_path", "operations");
     });
 
     return this.nquads;

--- a/src/storage/builders/operations/path_payment_op.ts
+++ b/src/storage/builders/operations/path_payment_op.ts
@@ -14,9 +14,13 @@ export class PathPaymentOpBuilder extends SpecificOperationBuilder {
     super.build();
     this.pushValue("send_max", this.xdr.sendMax().toString());
     this.pushValue("dest_amount", this.xdr.destAmount().toString());
-    this.pushBuilder(AccountBuilder.fromXDR(this.xdr.destination()), "account.destination", "operations");
-    this.pushBuilder(AssetBuilder.fromXDR(this.xdr.destAsset()), "asset.destination", "operations");
-    this.pushBuilder(AssetBuilder.fromXDR(this.xdr.sendAsset()), "asset.source", "operations");
+    this.pushBuilder(AccountBuilder.fromXDR(this.xdr.destination()), "op.destination");
+    this.pushBuilder(
+      AssetBuilder.fromXDR(this.xdr.destAsset()),
+      `${this.entityPrefix}.asset_destination`,
+      "operations"
+    );
+    this.pushBuilder(AssetBuilder.fromXDR(this.xdr.sendAsset()), `${this.entityPrefix}.asset_source`, "operations");
 
     (this.xdr.path() as any[]).forEach(xdr => {
       this.pushBuilder(AssetBuilder.fromXDR(xdr), "assets.path", "operations");
@@ -29,5 +33,9 @@ export class PathPaymentOpBuilder extends SpecificOperationBuilder {
     const resultBuilder = new PathPaymentResultBuilder(this.baseKey, this.trXDR.pathPaymentResult());
 
     this.pushBuilder(resultBuilder, "result");
+  }
+
+  private get entityPrefix() {
+    return "path_payment_op";
   }
 }

--- a/src/storage/builders/operations/payment_op.ts
+++ b/src/storage/builders/operations/payment_op.ts
@@ -13,14 +13,18 @@ export class PaymentOpBuilder extends SpecificOperationBuilder {
     const destination = publicKeyFromBuffer(this.xdr.destination().value());
 
     this.pushValue("amount", amount);
-    this.pushBuilder(new AccountBuilder(destination), "account.destination", "operations");
-    this.pushBuilder(new AssetBuilder(asset), "asset", "operations");
+    this.pushBuilder(new AccountBuilder(destination), "op.destination");
+    this.pushBuilder(new AssetBuilder(asset), `${this.entityPrefix}.asset`, "operations");
 
     return this.nquads;
   }
 
   protected pushResult() {
     const code = this.trXDR.paymentResult().switch().value;
-    this.pushValue("payment_result_code", code);
+    this.pushValue(`${this.entityPrefix}.result_code`, code);
+  }
+
+  private get entityPrefix() {
+    return "payment_op";
   }
 }

--- a/src/storage/builders/operations/payment_op.ts
+++ b/src/storage/builders/operations/payment_op.ts
@@ -19,9 +19,12 @@ export class PaymentOpBuilder extends SpecificOperationBuilder {
     return this.nquads;
   }
 
-  protected pushResult() {
-    const code = this.trXDR.paymentResult().switch().value;
-    this.pushValue(`${this.entityPrefix}.result_code`, code);
+  protected get resultCode() {
+    if (!this.trXDR) {
+      return;
+    }
+
+    return this.trXDR.paymentResult().switch().value;
   }
 
   private get entityPrefix() {

--- a/src/storage/builders/operations/set_options_op.ts
+++ b/src/storage/builders/operations/set_options_op.ts
@@ -7,9 +7,11 @@ export class SetOptionsOpBuilder extends SpecificOperationBuilder {
   public build(): NQuads {
     super.build();
 
-    this.pushValue("clear_flags", this.xdr.clearFlags());
-    this.pushValue("set_flags", this.xdr.setFlags());
-    this.pushValue("master_weight", this.xdr.masterWeight());
+    this.pushValues({
+      clear_flags: this.xdr.clearFlags(),
+      set_flags: this.xdr.setFlags(),
+      master_weight: this.xdr.masterWeight()
+    });
 
     this.pushInflationDest();
     this.pushThresholds();
@@ -22,7 +24,7 @@ export class SetOptionsOpBuilder extends SpecificOperationBuilder {
 
   protected pushResult() {
     const code = this.trXDR.setOptionsResult().switch().value;
-    this.pushValue("set_options_result_code", code);
+    this.pushValue(`${this.entityPrefix}.result_code`, code);
   }
 
   private pushThresholds() {
@@ -67,7 +69,7 @@ export class SetOptionsOpBuilder extends SpecificOperationBuilder {
     const signerNquad = NQuad.blank(`${this.current.value}_signer`);
     const signerBuilder = new AccountBuilder(signer.address);
 
-    this.nquads.push(new NQuad(this.current, "signer", signerNquad));
+    this.nquads.push(new NQuad(this.current, `${this.entityPrefix}.signer`, signerNquad));
     this.nquads.push(...signerBuilder.build());
 
     this.nquads.push(new NQuad(signerNquad, "account", signerBuilder.current));
@@ -80,6 +82,10 @@ export class SetOptionsOpBuilder extends SpecificOperationBuilder {
     }
 
     const inflationDestination = publicKeyFromBuffer(this.xdr.inflationDest().value());
-    this.pushBuilder(new AccountBuilder(inflationDestination), "account.inflation_dest");
+    this.pushBuilder(new AccountBuilder(inflationDestination), `${this.entityPrefix}.inflation_destination`);
+  }
+
+  private get entityPrefix() {
+    return "set_options_op";
   }
 }

--- a/src/storage/builders/operations/set_options_op.ts
+++ b/src/storage/builders/operations/set_options_op.ts
@@ -22,11 +22,6 @@ export class SetOptionsOpBuilder extends SpecificOperationBuilder {
     return this.nquads;
   }
 
-  protected pushResult() {
-    const code = this.trXDR.setOptionsResult().switch().value;
-    this.pushValue(`${this.entityPrefix}.result_code`, code);
-  }
-
   private pushThresholds() {
     const thresholds = {
       high: this.xdr.highThreshold(),
@@ -83,6 +78,14 @@ export class SetOptionsOpBuilder extends SpecificOperationBuilder {
 
     const inflationDestination = publicKeyFromBuffer(this.xdr.inflationDest().value());
     this.pushBuilder(new AccountBuilder(inflationDestination), `${this.entityPrefix}.inflation_destination`);
+  }
+
+  protected get resultCode() {
+    if (!this.trXDR) {
+      return;
+    }
+
+    return this.trXDR.setOptionsResult().switch().value;
   }
 
   private get entityPrefix() {

--- a/src/storage/builders/path_payment_result.ts
+++ b/src/storage/builders/path_payment_result.ts
@@ -22,11 +22,11 @@ export class PathPaymentResultBuilder extends Builder {
   public build(): NQuads {
     const code = this.xdr.switch().value;
     const resultCodes = stellar.xdr.PathPaymentResultCode;
-    this.pushValue("path_payment_result_code", code);
+    this.pushValue("path_payment_op.result_code", code);
 
     if (this.xdr.switch() !== resultCodes.pathPaymentSuccess()) {
       if (this.xdr.switch() === resultCodes.pathPaymentNoIssuer()) {
-        this.pushBuilder(AssetBuilder.fromXDR(this.xdr.noIssuer()), "no_issuer");
+        this.pushBuilder(AssetBuilder.fromXDR(this.xdr.noIssuer()), "path_payment_op.no_issuer");
       }
       return this.nquads;
     }
@@ -51,8 +51,8 @@ export class PathPaymentResultBuilder extends Builder {
     this.pushBuilder(lastAssetBuilder);
 
     this.nquads.push(new NQuad(lastNQuad, "key", NQuad.value(key)));
-    this.nquads.push(new NQuad(lastNQuad, "account.destination", destinationAccountBuilder.current));
-    this.nquads.push(new NQuad(lastNQuad, "asset", lastAssetBuilder.current));
+    this.nquads.push(new NQuad(lastNQuad, "destination", destinationAccountBuilder.current));
+    this.nquads.push(new NQuad(lastNQuad, "last.asset", lastAssetBuilder.current));
   }
 
   private pushOffers() {
@@ -74,14 +74,18 @@ export class PathPaymentResultBuilder extends Builder {
         this.pushBuilder(assetBoughtBuilder);
 
         this.nquads.push(new NQuad(offerNQuad, "key", NQuad.value(key)));
-        this.nquads.push(new NQuad(offerNQuad, "asset.sold", assetSoldBuilder.current));
-        this.nquads.push(new NQuad(offerNQuad, "asset.bought", assetBoughtBuilder.current));
+        this.nquads.push(new NQuad(offerNQuad, "asset_sold", assetSoldBuilder.current));
+        this.nquads.push(new NQuad(offerNQuad, "asset_bought", assetBoughtBuilder.current));
 
         this.nquads.push(new NQuad(offerNQuad, "offer_id", NQuad.value(offer.offerId().toString())));
         this.nquads.push(new NQuad(offerNQuad, "amount_sold", NQuad.value(offer.amountSold().toString())));
         this.nquads.push(new NQuad(offerNQuad, "amount_bought", NQuad.value(offer.amountBought().toString())));
 
-        this.nquads.push(new NQuad(this.current, "offers", offerNQuad));
+        this.nquads.push(new NQuad(this.current, `${this.entityPrefix}.offers`, offerNQuad));
       });
+  }
+
+  private get entityPrefix() {
+    return "path_payment_op";
   }
 }

--- a/src/storage/builders/specific_operation.ts
+++ b/src/storage/builders/specific_operation.ts
@@ -1,6 +1,6 @@
 import stellar from "stellar-base";
 
-import { IBlank, NQuads } from "../nquads";
+import { IBlank, NQuad, NQuads } from "../nquads";
 import { Builder } from "./";
 
 export abstract class SpecificOperationBuilder extends Builder {
@@ -16,12 +16,19 @@ export abstract class SpecificOperationBuilder extends Builder {
   }
 
   public build(): NQuads {
-    if (this.trXDR) {
-      this.pushResult();
-    }
-
+    this.pushResult();
     return this.nquads;
   }
 
-  protected abstract pushResult(): void;
+  protected abstract get resultCode(): number | undefined;
+
+  protected pushResult() {
+    if (this.resultCode === undefined) {
+      return;
+    }
+
+    const resultNQuad = NQuad.blank(`${this.current.value}_result`);
+    this.nquads.push(new NQuad(this.current, "op.result", resultNQuad));
+    this.nquads.push(new NQuad(resultNQuad, "result_code", NQuad.value(this.resultCode)));
+  }
 }

--- a/src/storage/builders/trade.ts
+++ b/src/storage/builders/trade.ts
@@ -1,0 +1,51 @@
+import { Asset } from "stellar-sdk";
+import { makeKey } from "../../util/crypto";
+import { AccountID } from "../../util/types";
+import { NQuad, NQuads, Subj } from "../nquads";
+import { AccountBuilder, AssetBuilder } from "./";
+import { Builder } from "./builder";
+
+interface ITradeCounterpart {
+  sellerId: AccountID;
+  buyerId: AccountID;
+  asset: Asset;
+  amount: number;
+  offerId: number;
+}
+
+export class TradeBuilder extends Builder {
+  public static key(offerId: number, sellerId: string, buyerId: string) {
+    return makeKey("trade", offerId.toString(), sellerId, buyerId);
+  }
+
+  public readonly current: Subj;
+
+  private sellerId: AccountID;
+  private buyerId: AccountID;
+  private asset: Asset;
+  private amount: number;
+  private offerId: number;
+
+  constructor(tradeData: ITradeCounterpart) {
+    super();
+    this.sellerId = tradeData.sellerId;
+    this.buyerId = tradeData.buyerId;
+    this.asset = tradeData.asset;
+    this.offerId = tradeData.offerId;
+    this.amount = tradeData.amount;
+
+    this.current = NQuad.blank(TradeBuilder.key(this.offerId, this.sellerId, this.buyerId));
+  }
+
+  public build(): NQuads {
+    this.pushKey();
+
+    this.pushValues({ trade: "", amount: this.amount, offer_id: this.offerId });
+
+    this.pushBuilder(new AccountBuilder(this.sellerId), "op.source");
+    this.pushBuilder(new AccountBuilder(this.buyerId), "op.destination");
+    this.pushBuilder(new AssetBuilder(this.asset), "trade.asset", "operations");
+
+    return this.nquads;
+  }
+}

--- a/src/storage/builders/transaction.ts
+++ b/src/storage/builders/transaction.ts
@@ -29,12 +29,9 @@ export class TransactionBuilder extends Builder {
 
   public build(): NQuads {
     const v = {
-      "type.transaction": "",
-      type: "transaction",
       key: this.current.value,
-      id: this.tx.id,
-      index: this.tx.index,
-      seq: this.seq,
+      "tx.id": this.tx.id,
+      "tx.index": this.tx.index,
       order: this.order(this.seq, this.tx.index),
       fee_amount: this.tx.feeAmount,
       fee_charged: this.tx.feeCharged,
@@ -50,8 +47,8 @@ export class TransactionBuilder extends Builder {
     this.pushValues(v);
     this.pushTimeBounds();
 
-    this.pushPrev();
-    this.pushLedger(this.seq);
+    this.pushPrev("tx");
+    this.pushLedger(this.seq, "tx");
     this.pushSourceAccount();
 
     return this.nquads;
@@ -59,7 +56,7 @@ export class TransactionBuilder extends Builder {
 
   private pushSourceAccount() {
     const account = new AccountBuilder(this.tx.sourceAccount);
-    this.pushBuilder(account, "account.source", "transactions");
+    this.pushBuilder(account, "tx.source");
   }
 
   private pushTimeBounds() {

--- a/src/storage/queries/account_operations.ts
+++ b/src/storage/queries/account_operations.ts
@@ -110,7 +110,7 @@ export class AccountOperationsQuery extends Query<IAccountOperationsQueryResult>
       const filters = FiltersBuilder.build(opKind, this.filters[opKind] || {});
 
       query += `
-        var(func: eq(id, $accountID)) @cascade  {
+        var(func: eq(account.id, $accountID)) @cascade  {
           ${opKind} as operations ${filters.root} {
             ${filters.nested}
           }
@@ -119,13 +119,13 @@ export class AccountOperationsQuery extends Query<IAccountOperationsQueryResult>
     });
 
     query += `
-      account(func: eq(id, $accountID)) {
+      account(func: eq(account.id, $accountID)) {
         operations @filter(uid(${this.kinds.join(",")})) (first: $first, offset: $offset, orderdesc: order) {
           kind
           index
           ledger { close_time }
           transaction { id }
-          account.source { id }
+          account.source { account.id }
           ${_
             .chain(this.kinds)
             .map(opKind => queryPredicates[opKind])

--- a/src/storage/queries/account_transactions.ts
+++ b/src/storage/queries/account_transactions.ts
@@ -35,7 +35,7 @@ export class AccountTransactionsQuery extends Query<IAccountTransactionsQueryRes
               offset: $offset,
               orderdesc: order
             ) {
-              account.source { id }
+              account.source { account.id }
               memo.value
               memo.type
               fee_amount

--- a/src/storage/queries/asset_operations.ts
+++ b/src/storage/queries/asset_operations.ts
@@ -35,14 +35,14 @@ export class AssetOperationsQuery extends Query<IAssetOperationsQueryResult> {
     const opKindFilter = this.kinds.map(opKind => `has(kind.${opKind})`).join(" OR ");
 
     const query = `query assetOperations($code: string, $issuer: string, $first: int, $offset: int) {
-      issuer(func: eq(id, $issuer)) {
+      issuer(func: eq(account.id, $issuer)) {
         assets.issued @filter(eq(code, $code))  {
           operations @filter(${opKindFilter}) (first: $first, offset: $offset, orderdesc: order) {
             kind
             index
             ledger { close_time }
             transaction { id }
-            account.source { id }
+            account.source { account.id }
             ${_
               .chain(this.kinds)
               .map(opKind => queryPredicates[opKind])

--- a/src/storage/queries/asset_operations.ts
+++ b/src/storage/queries/asset_operations.ts
@@ -27,7 +27,7 @@ export class AssetOperationsQuery extends Query<IAssetOperationsQueryResult> {
 
   public async call(): Promise<IAssetOperationsQueryResult> {
     const r = await this.request();
-    const ops = _.at(r, "issuer[0].['assets.issued'][0].operations");
+    const ops = _.at(r, "issuer[0]['~asset.issuer'][0].operations");
     return (ops[0] || []).map(OperationFactory.fromDgraph);
   }
 
@@ -36,7 +36,7 @@ export class AssetOperationsQuery extends Query<IAssetOperationsQueryResult> {
 
     const query = `query assetOperations($code: string, $issuer: string, $first: int, $offset: int) {
       issuer(func: eq(account.id, $issuer)) {
-        assets.issued @filter(eq(code, $code))  {
+        ~asset.issuer @filter(eq(code, $code))  {
           operations @filter(${opKindFilter}) (first: $first, offset: $offset, orderdesc: order) {
             kind
             index

--- a/src/storage/queries/operations/filters_builder.ts
+++ b/src/storage/queries/operations/filters_builder.ts
@@ -88,9 +88,9 @@ function buildPaymentsFilters(params: IPaymentsQueryParams) {
   return {
     root: [],
     nested: _.filter([
-      params.asset && buildAssetFilter(params.asset.code, params.asset.issuer),
-      params.destination && `account.destination @filter(eq(id, "${params.destination}"))`,
-      params.source && `account.source @filter(eq(id, "${params.source}"))`
+      params.asset && buildAssetFilter(params.asset.code, params.asset.issuer, "payment_op.asset"),
+      params.destination && `op.destination @filter(eq(account.id, "${params.destination}"))`,
+      params.source && `op.source @filter(eq(account.id, "${params.source}"))`
     ]) as string[]
   };
 }
@@ -98,7 +98,7 @@ function buildPaymentsFilters(params: IPaymentsQueryParams) {
 function buildAccountMergeFilters(params: IAccountMergeQueryParams) {
   return {
     root: [],
-    nested: params.destination ? [`account.destination @filter(eq(id, "${params.destination}"))`] : []
+    nested: params.destination ? [`op.destination @filter(eq(account.id, "${params.destination}"))`] : []
   };
 }
 
@@ -115,7 +115,7 @@ function buildAllowTrustFilters(params: IAllowTrustQueryParams) {
 
   return {
     root: filters,
-    nested: params.trustor ? [`trustor @filter(eq(id, "${params.trustor}"))`] : []
+    nested: params.trustor ? [`allow_trust_op.trustor @filter(eq(account.id, "${params.trustor}"))`] : []
   };
 }
 
@@ -136,7 +136,7 @@ function buildChangeTrustFilters(params: IChangeTrustQueryParams) {
 function buildCreateAccountFilters(params: ICreateAccountQueryParams) {
   return {
     root: [],
-    nested: params.destination ? [`account.destination @filter(eq(id, "${params.destination}"))`] : []
+    nested: params.destination ? [`op.destination @filter(eq(account.id, "${params.destination}"))`] : []
   };
 }
 
@@ -173,8 +173,8 @@ function buildPathPaymentsFilters(params: IPathPaymentsQueryParams) {
       params.destinationAsset &&
         buildAssetFilter(params.destinationAsset.code, params.destinationAsset.issuer, "asset.destination"),
       params.sourceAsset && buildAssetFilter(params.sourceAsset.code, params.sourceAsset.issuer, "asset.source"),
-      params.destinationAccount && `account.destination @filter(eq(id, "${params.destinationAccount}"))`,
-      params.sourceAccount && `account.source @filter(eq(id, "${params.sourceAccount}"))`,
+      params.destinationAccount && `op.destination @filter(eq(account.id, "${params.destinationAccount}"))`,
+      params.sourceAccount && `op.source @filter(eq(account.id, "${params.sourceAccount}"))`,
       params.pathContains && buildAssetFilter(params.pathContains.code, params.pathContains.issuer, "assets.path")
     ])
   };

--- a/src/storage/queries/operations/predicates.ts
+++ b/src/storage/queries/operations/predicates.ts
@@ -4,12 +4,12 @@ import { OperationKinds } from "../../../model/operation";
 
 export const queryPredicates = {
   [OperationKinds.Payment]: [
-    "account.destination { id }",
+    "account.destination { account.id }",
     "amount",
     `asset {
       native
       code
-      issuer { id }
+      issuer { account.id }
     }`
   ],
   [OperationKinds.SetOption]: [
@@ -22,24 +22,24 @@ export const queryPredicates = {
       med
       low
     }`,
-    "account.inflation_dest { id }",
+    "account.inflation_dest { account.id }",
     `signer {
-      account { id }
+      account { account.id }
       weight
     }`
   ],
-  [OperationKinds.AccountMerge]: ["account.destination { id }"],
-  [OperationKinds.AllowTrust]: ["trustor { id }", "asset_code", "authorize"],
+  [OperationKinds.AccountMerge]: ["account.destination { account.id }"],
+  [OperationKinds.AllowTrust]: ["trustor { account.id }", "asset_code", "authorize"],
   [OperationKinds.BumpSequence]: ["bump_to"],
   [OperationKinds.ChangeTrust]: [
     "limit",
     `asset {
       native
       code
-      issuer { id }
+      issuer { account.id }
     }`
   ],
-  [OperationKinds.CreateAccount]: ["starting_balance", "account.destination { id }"],
+  [OperationKinds.CreateAccount]: ["starting_balance", "account.destination { account.id }"],
   [OperationKinds.ManageData]: ["name", "value"],
   [OperationKinds.ManageOffer]: [
     "offer_id",
@@ -49,33 +49,33 @@ export const queryPredicates = {
     `asset.buying {
       native
       code
-      issuer { id }
+      issuer { account.id }
     }`,
     `asset.selling {
       native
       code
-      issuer { id }
+      issuer { account.id }
     }`,
     "amount"
   ],
   [OperationKinds.PathPayment]: [
     "send_max",
     "dest_amount",
-    "account.destination { id }",
+    "account.destination { account.id }",
     `asset.destination {
       native
       code
-      issuer { id }
+      issuer { account.id }
     }`,
     `asset.source {
       native
       code
-      issuer { id }
+      issuer { account.id }
     }`,
     `assets.path {
       native
       code
-      issuer { id }
+      issuer { account.id }
     }`
   ]
 };

--- a/src/storage/queries/operations/predicates.ts
+++ b/src/storage/queries/operations/predicates.ts
@@ -4,9 +4,9 @@ import { OperationKinds } from "../../../model/operation";
 
 export const queryPredicates = {
   [OperationKinds.Payment]: [
-    "account.destination { account.id }",
+    "op.destination { account.id }",
     "amount",
-    `asset {
+    `payment_op.asset {
       native
       code
       asset.issuer { account.id }
@@ -22,36 +22,44 @@ export const queryPredicates = {
       med
       low
     }`,
-    "account.inflation_dest { account.id }",
-    `signer {
+    "set_options_op.inflation_destination { account.id }",
+    `set_options_op.signer {
       account { account.id }
       weight
     }`
   ],
-  [OperationKinds.AccountMerge]: ["account.destination { account.id }"],
-  [OperationKinds.AllowTrust]: ["trustor { account.id }", "asset_code", "authorize"],
+  [OperationKinds.AccountMerge]: ["op.destination { account.id }"],
+  [OperationKinds.AllowTrust]: [
+    "allow_trust_op.trustor { account.id }",
+    `allow_trust_op.asset {
+      code
+      issuer { account.id }
+      native
+    }`,
+    "authorize"
+  ],
   [OperationKinds.BumpSequence]: ["bump_to"],
   [OperationKinds.ChangeTrust]: [
     "limit",
-    `asset {
+    `change_trust_op.asset {
       native
       code
       asset.issuer { account.id }
     }`
   ],
-  [OperationKinds.CreateAccount]: ["starting_balance", "account.destination { account.id }"],
+  [OperationKinds.CreateAccount]: ["starting_balance", "op.destination { account.id }"],
   [OperationKinds.ManageData]: ["name", "value"],
   [OperationKinds.ManageOffer]: [
     "offer_id",
     "price_n",
     "price_d",
     "price",
-    `asset.buying {
+    `manage_offer_op.asset buying {
       native
       code
       asset.issuer { account.id }
     }`,
-    `asset.selling {
+    `manage_offer_op.asset_selling {
       native
       code
       asset.issuer { account.id }
@@ -61,18 +69,18 @@ export const queryPredicates = {
   [OperationKinds.PathPayment]: [
     "send_max",
     "dest_amount",
-    "account.destination { account.id }",
-    `asset.destination {
+    "op.destination { account.id }",
+    `path_payment_op.asset_destination {
       native
       code
       asset.issuer { account.id }
     }`,
-    `asset.source {
+    `path_payment_op.asset_source {
       native
       code
       asset.issuer { account.id }
     }`,
-    `assets.path {
+    `path_payment_op.assets_path {
       native
       code
       asset.issuer { account.id }

--- a/src/storage/queries/operations/predicates.ts
+++ b/src/storage/queries/operations/predicates.ts
@@ -9,7 +9,7 @@ export const queryPredicates = {
     `asset {
       native
       code
-      issuer { account.id }
+      asset.issuer { account.id }
     }`
   ],
   [OperationKinds.SetOption]: [
@@ -36,7 +36,7 @@ export const queryPredicates = {
     `asset {
       native
       code
-      issuer { account.id }
+      asset.issuer { account.id }
     }`
   ],
   [OperationKinds.CreateAccount]: ["starting_balance", "account.destination { account.id }"],
@@ -49,12 +49,12 @@ export const queryPredicates = {
     `asset.buying {
       native
       code
-      issuer { account.id }
+      asset.issuer { account.id }
     }`,
     `asset.selling {
       native
       code
-      issuer { account.id }
+      asset.issuer { account.id }
     }`,
     "amount"
   ],
@@ -65,17 +65,17 @@ export const queryPredicates = {
     `asset.destination {
       native
       code
-      issuer { account.id }
+      asset.issuer { account.id }
     }`,
     `asset.source {
       native
       code
-      issuer { account.id }
+      asset.issuer { account.id }
     }`,
     `assets.path {
       native
       code
-      issuer { account.id }
+      asset.issuer { account.id }
     }`
   ]
 };

--- a/src/storage/queries/operations/predicates.ts
+++ b/src/storage/queries/operations/predicates.ts
@@ -68,7 +68,7 @@ export const queryPredicates = {
   ],
   [OperationKinds.PathPayment]: [
     "send_max",
-    "dest_amount",
+    "amount",
     "op.destination { account.id }",
     `path_payment_op.asset_destination {
       native

--- a/src/storage/schema.ts
+++ b/src/storage/schema.ts
@@ -128,10 +128,7 @@ const schemaWithComments = `
 
   # signer
   account: [uid] .
-  weight: int . 
-
-  # operation result
-  result_code: int @index(int) .
+  weight: int .
 `;
 
 // remove comments

--- a/src/storage/schema.ts
+++ b/src/storage/schema.ts
@@ -15,7 +15,7 @@ const schemaWithComments = `
 
   # ledgers
   ledger.id: int @index(int) .
-  ledger.prev: uid @reverse .
+  ledger.prev: [uid] @reverse .
   version: int .
   base_fee: int .
   base_reserve: int .
@@ -29,16 +29,16 @@ const schemaWithComments = `
 
   # assets
   asset.id: string @index(exact) .
-  asset.issuer: uid @reverse .
+  asset.issuer: [uid] @reverse .
   code: string @index(exact) .
   native: bool @index(bool) .
 
   # transactions
   tx.id: string @index(exact) .
-  tx.ledger: uid @reverse .
-  tx.source: uid @reverse .
+  tx.ledger: [uid] @reverse .
+  tx.source: [uid] @reverse .
   tx.index: int .
-  tx.prev: uid @reverse .
+  tx.prev: [uid] @reverse .
   result_code: int @index(int) .
   fee_amount: int .
   fee_charged: int .
@@ -53,23 +53,23 @@ const schemaWithComments = `
 
   # operations
   op.id: string @index(exact) .
-  op.transaction: uid @reverse .
-  op.ledger: uid @reverse .
+  op.transaction: [uid] @reverse .
+  op.ledger: [uid] @reverse .
   op.index: int .
-  op.source: uid @reverse .
-  op.destination: uid @reverse .
+  op.source: [uid] @reverse .
+  op.destination: [uid] @reverse .
   op.kind: string @index(hash) .
-  op.prev: uid @reverse .
-  op.result: uid @reverse .
+  op.prev: [uid] @reverse .
+  op.result: [uid] @reverse .
   amount: int .
 
   # account merge
   account_merge_op.result_code: int .
 
   # allow trust
-  allow_trust_op.trustor: uid @reverse .
+  allow_trust_op.trustor: [uid] @reverse .
   allow_trust_op.result_code: int .
-  allow_trust_op.asset: uid @reverse .
+  allow_trust_op.asset: [uid] @reverse .
   authorize: bool @index(bool) .
 
   # bump sequence
@@ -77,7 +77,7 @@ const schemaWithComments = `
   bump_to: int @index(int) .
 
   # change trust
-  change_trust_op.asset: uid @reverse .
+  change_trust_op.asset: [uid] @reverse .
   change_trust_op.result_code: int .
   limit: int @index(int) .
 
@@ -91,8 +91,8 @@ const schemaWithComments = `
   value: string @index(exact) . 
 
   # manage offer
-  manage_offer_op.asset_buying: uid @reverse .
-  manage_offer_op.asset_selling: uid @reverse .
+  manage_offer_op.asset_buying: [uid] @reverse .
+  manage_offer_op.asset_selling: [uid] @reverse .
   manage_offer_op.result_code: int .
   price_n: int .
   price_d: int .
@@ -100,26 +100,26 @@ const schemaWithComments = `
   offer_id: int @index(int) .
 
   # payment
-  payment_op.asset: uid @reverse .
+  payment_op.asset: [uid] @reverse .
   payment_op.result_code: int .
 
   # path payment
-  path_payment_op.asset_source: uid @reverse .
-  path_payment_op.asset_destination: uid @reverse .
-  path_payment_op.assets_path: uid @reverse .
+  path_payment_op.asset_source: [uid] @reverse .
+  path_payment_op.asset_destination: [uid] @reverse .
+  path_payment_op.assets_path: [uid] @reverse .
   path_payment_op.result_code: int .
   send_max: int .
   
   # set options
-  set_options_op.signer: uid @reverse .
-  set_options_op.inflation_destination: uid @reverse .
+  set_options_op.signer: [uid] @reverse .
+  set_options_op.inflation_destination: [uid] @reverse .
   set_options_op.result_code: int .
-  set_options_op.signer: uid .
+  set_options_op.signer: [uid] .
   clear_flags: int .
   set_flags: int .
   master_weight: int .
   home_domain: string .
-  thresholds: uid .
+  thresholds: [uid] .
 
   # thresholds
   high: int .
@@ -127,7 +127,7 @@ const schemaWithComments = `
   low: int .
 
   # signer
-  account: uid .
+  account: [uid] .
   weight: int . 
 
   # operation result

--- a/src/storage/schema.ts
+++ b/src/storage/schema.ts
@@ -109,7 +109,6 @@ const schemaWithComments = `
   path_payment_op.assets_path: uid @reverse .
   path_payment_op.result_code: int .
   send_max: int .
-  dest_amount: int .
   
   # set options
   set_options_op.signer: uid @reverse .

--- a/src/storage/schema.ts
+++ b/src/storage/schema.ts
@@ -97,7 +97,7 @@ const schemaWithComments = `
   price_n: int .
   price_d: int .
   price: float .
-  offer_id: string @index (exact) .
+  offer_id: int @index(int) .
 
   # payment
   payment_op.asset: uid @reverse .

--- a/src/storage/schema.ts
+++ b/src/storage/schema.ts
@@ -39,7 +39,7 @@ const schemaWithComments = `
   tx.source: uid @reverse .
   tx.index: int .
   tx.prev: uid @reverse .
-  result_code: int .
+  result_code: int @index(int) .
   fee_amount: int .
   fee_charged: int .
   success: bool @index(bool) .
@@ -60,10 +60,10 @@ const schemaWithComments = `
   op.destination: uid @reverse .
   op.kind: string @index(hash) .
   op.prev: uid @reverse .
+  op.result: uid @reverse .
   amount: int .
 
   # account merge
-  result: uid .
   account_merge_op.result_code: int .
 
   # allow trust
@@ -128,23 +128,10 @@ const schemaWithComments = `
 
   # signer
   account: uid .
-  weight: int .
+  weight: int . 
 
-  # operation results
-  # account merge result
-  source_account_balance: int .
-
-  # path payment result
-  path_payment_result.no_issuer: uid .
-  path_payment_result.last: uid .
-  destination: uid .
-  last.asset: uid .
-  path_payment_result.offers: uid .
-  asset_sold: uid .
-  asset_bought: uid .
-  amount_sold: int .
-  amount_bought: int .
-  seller: uid .
+  # operation result
+  result_code: int @index(int) .
 `;
 
 // remove comments

--- a/src/storage/schema.ts
+++ b/src/storage/schema.ts
@@ -54,6 +54,7 @@ const schemaWithComments = `
   # operations
   op.id: string @index(exact) .
   op.transaction: uid @reverse .
+  op.ledger: uid @reverse .
   op.index: int .
   op.source: uid @reverse .
   op.destination: uid @reverse .
@@ -100,7 +101,7 @@ const schemaWithComments = `
 
   # payment
   payment_op.asset: uid @reverse .
-  payment_result_code: int .
+  payment_op.result_code: int .
 
   # path payment
   path_payment_op.asset_source: uid @reverse .
@@ -112,12 +113,12 @@ const schemaWithComments = `
   
   # set options
   set_options_op.signer: uid @reverse .
-  set_options_op.inflation_destination: uid .
+  set_options_op.inflation_destination: uid @reverse .
   set_options_op.result_code: int .
+  set_options_op.signer: uid .
   clear_flags: int .
   set_flags: int .
   master_weight: int .
-  signer: uid .
   home_domain: string .
   thresholds: uid .
 

--- a/src/storage/schema.ts
+++ b/src/storage/schema.ts
@@ -4,12 +4,6 @@ const schemaWithComments = `
   # common
   order: int @index(int) .
   key: string @index(hash) .
-  type.account: string .
-  type.asset: string .
-  type.ledger: string .
-  type.operation: string .
-  type.transaction: string .
-  type.trust_line_entry: string .
   kind.setOption: string .
   kind.payment: string .
   kind.pathPayment: string .
@@ -21,11 +15,12 @@ const schemaWithComments = `
 
   # ledgers
   ledger.id: int @index(int) .
+  ledger.prev: uid @reverse .
   version: int .
   base_fee: int .
   base_reserve: int .
   max_tx_set_size: int .
-  close_time: dateTime @index(hour) .
+  close_time: datetime @index(hour) .
   _ingested: bool .
 
   # accounts
@@ -43,7 +38,7 @@ const schemaWithComments = `
   tx.ledger: uid @reverse .
   tx.source: uid @reverse .
   tx.index: int .
-  tx.next: uid @reverse .
+  tx.prev: uid @reverse .
   result_code: int .
   fee_amount: int .
   fee_charged: int .
@@ -53,7 +48,7 @@ const schemaWithComments = `
   memo.type: string .
   memo.value: string .
 
-  # trustline entry
+  # ledger change
   balance: string .
 
   # operations
@@ -63,39 +58,41 @@ const schemaWithComments = `
   op.source: uid @reverse .
   op.destination: uid @reverse .
   op.kind: string @index(hash) .
+  op.prev: uid @reverse .
   amount: int .
 
   # account merge
   result: uid .
-  account_merge_result_code: int .
+  account_merge_op.result_code: int .
 
   # allow trust
   allow_trust_op.trustor: uid @reverse .
-  asset_code: string @index(exact) .
+  allow_trust_op.result_code: int .
+  allow_trust_op.asset: uid @reverse .
   authorize: bool @index(bool) .
-  allow_trust_result_code: int .
 
   # bump sequence
+  bump_sequence_op.result_code: int .
   bump_to: int @index(int) .
-  bump_sequence_result_code: int .
 
   # change trust
   change_trust_op.asset: uid @reverse .
+  change_trust_op.result_code: int .
   limit: int @index(int) .
-  change_trust_result_code: int .
 
   # create account
   starting_balance: int @index(int) .
-  create_account_result_code: int .
+  create_account_op.result_code: int .
 
   # manage data
+  manage_data_op.result_code: int .
   name: string @index(exact) .
   value: string @index(exact) . 
-  manage_data_result_code: int .
 
   # manage offer
   manage_offer_op.asset_buying: uid @reverse .
   manage_offer_op.asset_selling: uid @reverse .
+  manage_offer_op.result_code: int .
   price_n: int .
   price_d: int .
   price: float .
@@ -109,20 +106,20 @@ const schemaWithComments = `
   path_payment_op.asset_source: uid @reverse .
   path_payment_op.asset_destination: uid @reverse .
   path_payment_op.assets_path: uid @reverse .
+  path_payment_op.result_code: int .
   send_max: int .
   dest_amount: int .
-  path_payment_result_code: int .
   
   # set options
   set_options_op.signer: uid @reverse .
   set_options_op.inflation_destination: uid .
+  set_options_op.result_code: int .
   clear_flags: int .
   set_flags: int .
   master_weight: int .
   signer: uid .
   home_domain: string .
   thresholds: uid .
-  set_options_result_code: int .
 
   # thresholds
   high: int .

--- a/src/storage/schema.ts
+++ b/src/storage/schema.ts
@@ -114,7 +114,6 @@ const schemaWithComments = `
   set_options_op.signer: [uid] @reverse .
   set_options_op.inflation_destination: [uid] @reverse .
   set_options_op.result_code: int .
-  set_options_op.signer: [uid] .
   clear_flags: int .
   set_flags: int .
   master_weight: int .
@@ -129,6 +128,10 @@ const schemaWithComments = `
   # signer
   account: [uid] .
   weight: int .
+
+  # trade
+  trade.asset: [uid] @reverse .
+  trade.counterpart: [uid] .
 `;
 
 // remove comments

--- a/src/storage/schema.ts
+++ b/src/storage/schema.ts
@@ -4,6 +4,20 @@ const schemaWithComments = `
   # common
   order: int @index(int) .
   key: string @index(hash) .
+  type.account: string .
+  type.asset: string .
+  type.ledger: string .
+  type.operation: string .
+  type.transaction: string .
+  type.trust_line_entry: string .
+  kind.setOption: string .
+  kind.payment: string .
+  kind.pathPayment: string .
+  kind.manageOffer: string .
+  kind.manageDatum: string .
+  kind.createAccount: string .
+  kind.changeTrust: string .
+  kind.allowTrust: string .
 
   # ledgers
   ledger.id: int @index(int) .
@@ -12,6 +26,7 @@ const schemaWithComments = `
   base_reserve: int .
   max_tx_set_size: int .
   close_time: dateTime @index(hour) .
+  _ingested: bool .
 
   # accounts
   account.id: string @index(exact) .
@@ -37,6 +52,9 @@ const schemaWithComments = `
   time_bounds.max: dateTime .
   memo.type: string .
   memo.value: string .
+
+  # trustline entry
+  balance: string .
 
   # operations
   op.id: string @index(exact) .
@@ -93,6 +111,7 @@ const schemaWithComments = `
   path_payment_op.assets_path: uid @reverse .
   send_max: int .
   dest_amount: int .
+  path_payment_result_code: int .
   
   # set options
   set_options_op.signer: uid @reverse .

--- a/src/storage/schema.ts
+++ b/src/storage/schema.ts
@@ -4,152 +4,134 @@ const schemaWithComments = `
   # common
   order: int @index(int) .
   key: string @index(hash) .
-  id: string @index(exact) .
-  type: string @index(hash) .
-  type.account: default .
-  type.asset: default .
-  type.ledger: default .
-  type.operation: default .
-  type.transaction: default .
-  type.trust_line_entry: default .
-  kind.accountMerge: default .
-  kind.allowTrust: default .
-  kind.changeTrust: default .
-  kind.createAccount: default .
-  kind.createPassiveOffer: default .
-  kind.inflation: default .
-  kind.manageDatum: default .
-  kind.manageOffer: default .
-  kind.pathPayment: default .
-  kind.payment: default .
-  kind.setOption: default .
-  index: int @index(int) .
-  account.source: uid .
-  ledger: uid .
-  next: uid .
-  prev: uid .
-  asset: uid .
 
   # ledgers
-  seq: int @index(int) .
-  version: default .
-  base_fee: default .
-  base_reserve: default .
-  max_tx_set_size: default .
-  close_time: datetime @index(hour) .
-  _ingested: default .
+  ledger.id: int @index(int) .
+  version: int .
+  base_fee: int .
+  base_reserve: int .
+  max_tx_set_size: int .
+  close_time: dateTime @index(hour) .
 
   # accounts
+  account.id: string @index(exact) .
   deleted: bool @index(bool) .
-  assets.issued: uid .
-  operations: uid .
-  transactions: uid .
 
   # assets
-  asset.id: default .
-  issuer: uid .
+  asset.id: string @index(exact) .
+  asset.issuer: uid @reverse .
   code: string @index(exact) .
   native: bool @index(bool) .
 
   # transactions
-  result_code: default .
-  fee_amount: default .
-  fee_charged: default .
-  success: default .
-  time_bounds.min: default .
-  time_bounds.max: default .
-  memo.type: default .
-  memo.value: default .
-
-  # trustline entry
-  balance: default .
+  tx.id: string @index(exact) .
+  tx.ledger: uid @reverse .
+  tx.source: uid @reverse .
+  tx.index: int .
+  tx.next: uid @reverse .
+  result_code: int .
+  fee_amount: int .
+  fee_charged: int .
+  success: bool @index(bool) .
+  time_bounds.min: dateTime .
+  time_bounds.max: dateTime .
+  memo.type: string .
+  memo.value: string .
 
   # operations
-  transaction: uid .
-  kind: string @index(hash) .
-  amount: int @index(int) .
-  account.destination: uid .
-  result: uid .
+  op.id: string @index(exact) .
+  op.transaction: uid @reverse .
+  op.index: int .
+  op.source: uid @reverse .
+  op.destination: uid @reverse .
+  op.kind: string @index(hash) .
+  amount: int .
 
   # account merge
-  account_merge_result_code: default .
+  result: uid .
+  account_merge_result_code: int .
 
   # allow trust
-  trustor: uid .
+  allow_trust_op.trustor: uid @reverse .
   asset_code: string @index(exact) .
   authorize: bool @index(bool) .
-  allow_trust_result_code: default .
+  allow_trust_result_code: int .
 
   # bump sequence
   bump_to: int @index(int) .
+  bump_sequence_result_code: int .
 
   # change trust
+  change_trust_op.asset: uid @reverse .
   limit: int @index(int) .
-  change_trust_result_code: default .
+  change_trust_result_code: int .
 
   # create account
   starting_balance: int @index(int) .
-  create_account_result_code: default .
+  create_account_result_code: int .
 
   # manage data
   name: string @index(exact) .
-  value: string @index(exact) .
-  manage_data_result_code: default .
+  value: string @index(exact) . 
+  manage_data_result_code: int .
 
   # manage offer
-  asset.buying: uid .
-  asset.selling: uid .
-  price_n: default .
-  price_d: default .
-  price: float @index(float) .
-  offer_id: string @index(exact) .
+  manage_offer_op.asset_buying: uid @reverse .
+  manage_offer_op.asset_selling: uid @reverse .
+  price_n: int .
+  price_d: int .
+  price: float .
+  offer_id: string @index (exact) .
 
   # payment
-  payment_result_code: default .
+  payment_op.asset: uid @reverse .
+  payment_result_code: int .
 
   # path payment
-  asset.source: uid .
-  asset.destination: uid .
-  assets.path: uid .
-  send_max: default .
-  dest_amount: default .
-  path_payment_result_code: default .
-
+  path_payment_op.asset_source: uid @reverse .
+  path_payment_op.asset_destination: uid @reverse .
+  path_payment_op.assets_path: uid @reverse .
+  send_max: int .
+  dest_amount: int .
+  
   # set options
+  set_options_op.signer: uid @reverse .
+  set_options_op.inflation_destination: uid .
+  clear_flags: int .
+  set_flags: int .
+  master_weight: int .
   signer: uid .
-  account.inflation_dest: uid .
-  clear_flags: default .
-  set_flags: default .
-  master_weight: default .
-  home_domain: default .
+  home_domain: string .
   thresholds: uid .
-  set_options_result_code: default .
+  set_options_result_code: int .
 
   # thresholds
-  low: default .
-  med: default .
-  high: default .
+  high: int .
+  med: int .
+  low: int .
 
   # signer
   account: uid .
-  weight: default .
+  weight: int .
 
   # operation results
   # account merge result
   source_account_balance: int .
 
   # path payment result
-  no_issuer: uid .
-  last: uid .
-  offers: uid .
-  asset.sold: uid .
-  asset.bought: uid .
-  amount_sold: default .
-  amount_bought: default .
+  path_payment_result.no_issuer: uid .
+  path_payment_result.last: uid .
+  destination: uid .
+  last.asset: uid .
+  path_payment_result.offers: uid .
+  asset_sold: uid .
+  asset_bought: uid .
+  amount_sold: int .
+  amount_bought: int .
   seller: uid .
 `;
 
 // remove comments
-const validDgraphSchema = schemaWithComments.replace(/#.+$/gm, "");
+const validDgraphSchema = schemaWithComments.replace(/#.+$/mg, "");
 
 export { validDgraphSchema as SCHEMA };

--- a/src/storage/schema.ts
+++ b/src/storage/schema.ts
@@ -132,6 +132,6 @@ const schemaWithComments = `
 `;
 
 // remove comments
-const validDgraphSchema = schemaWithComments.replace(/#.+$/mg, "");
+const validDgraphSchema = schemaWithComments.replace(/#.+$/gm, "");
 
 export { validDgraphSchema as SCHEMA };

--- a/src/storage/types.ts
+++ b/src/storage/types.ts
@@ -6,9 +6,9 @@ import { OperationKinds } from "../model/operation";
 import { MemoType } from "../util/stellar";
 
 export interface ITransactionData {
-  id: string;
-  seq: string;
-  index: string;
+  "tx.id": string;
+  "tx.index": string;
+  "tx.ledger": ILedgerData[];
   // body
   "memo.value": string | null;
   "memo.type": MemoType | null;
@@ -19,7 +19,7 @@ export interface ITransactionData {
   // result
   // meta
   // feeMeta
-  "account.source": IAccountData[];
+  "tx.source": IAccountData[];
   // Datetime ISO string
   "time_bounds.min": string;
   "time_bounds.max": string;

--- a/src/storage/types.ts
+++ b/src/storage/types.ts
@@ -121,7 +121,7 @@ export interface IAssetData {
 }
 
 export interface IAccountData {
-  id: AccountID;
+  "account.id": AccountID;
   // it's incomplete
 }
 

--- a/src/storage/types.ts
+++ b/src/storage/types.ts
@@ -115,8 +115,9 @@ export type DgraphOperationsData = IPaymentOperationData &
   IPathPaymentOperationData;
 
 export interface IAssetData {
+  "asset.id": string;
   code: AssetCode;
-  issuer: IAccountData[];
+  "asset.issuer": IAccountData[];
   native: boolean;
 }
 

--- a/src/storage/types.ts
+++ b/src/storage/types.ts
@@ -92,7 +92,7 @@ export interface IManageOfferOperationData extends IOperationData {
 
 export interface IPathPaymentOperationData extends IOperationData {
   send_max: string;
-  dest_amount: string;
+  amount: string;
   "path_payment_op.asset_destination": IAssetData[];
   "path_payment_op.asset_source": IAssetData[];
   "path_payment_op.assets_path": IAssetData[];

--- a/src/storage/types.ts
+++ b/src/storage/types.ts
@@ -26,17 +26,17 @@ export interface ITransactionData {
 }
 
 interface IOperationData {
-  kind: OperationKinds;
-  ledger: ILedgerData[];
-  index: string;
-  transaction: ITransactionData[];
+  "op.kind": OperationKinds;
+  "op.ledger": ILedgerData[];
+  "op.index": string;
+  "op.transaction": ITransactionData[];
+  "op.source": IAccountData[];
+  "op.destination": IAccountData[];
 }
 
 export interface IPaymentOperationData extends IOperationData {
-  "account.source": IAccountData[];
-  "account.destination": IAccountData[];
   amount: string;
-  asset: IAssetData[];
+  "payment_op.asset": IAssetData[];
 }
 
 export interface ISetOptionsOperationData extends IOperationData {
@@ -49,20 +49,16 @@ export interface ISetOptionsOperationData extends IOperationData {
     med: string;
     low: string;
   };
-  "account.inflation_dest": IAccountData[];
-  signer: {
+  "set_options_op.inflation_destination": IAccountData[];
+  "set_options_op.signer": {
     account: IAccountData[];
     weight: string;
   };
 }
 
-export interface IAccountMergeOperationData extends IOperationData {
-  "account.destination": IAccountData[];
-}
-
 export interface IAllowTrustOperationData extends IOperationData {
-  trustor: IAccountData[];
-  asset_code: AssetCode;
+  "allow_trust_op.trustor": IAccountData[];
+  "allow_trust_op.asset": IAssetData[];
   authorize: boolean;
 }
 
@@ -72,13 +68,13 @@ export interface IBumpSequenceOperationData extends IOperationData {
 
 export interface IChangeTrustOperationData extends IOperationData {
   limit: string;
-  asset: IAssetData[];
+  "change_trust_op.asset": IAssetData[];
 }
 
 export interface ICreateAccountOperationData extends IOperationData {
   starting_balance: string;
-  "account.destination": IAccountData[];
 }
+
 export interface IManageDataOperationData extends IOperationData {
   name: string;
   value: string;
@@ -89,23 +85,21 @@ export interface IManageOfferOperationData extends IOperationData {
   price_d: string;
   price: number;
   offer_id: string;
-  "asset.selling": IAssetData[];
-  "asset.buying": IAssetData[];
+  "manage_offer_op.asset_selling": IAssetData[];
+  "manage_offer_op.asset_buying": IAssetData[];
   amount: number;
 }
 
 export interface IPathPaymentOperationData extends IOperationData {
   send_max: string;
   dest_amount: string;
-  "account.destination": IAccountData[];
-  "asset.destination": IAssetData[];
-  "asset.source": IAssetData[];
-  "assets.path": IAssetData[];
+  "path_payment_op.asset_destination": IAssetData[];
+  "path_payment_op.asset_source": IAssetData[];
+  "path_payment_op.assets_path": IAssetData[];
 }
 
 export type DgraphOperationsData = IPaymentOperationData &
   ISetOptionsOperationData &
-  IAccountMergeOperationData &
   IAllowTrustOperationData &
   IBumpSequenceOperationData &
   IChangeTrustOperationData &

--- a/src/util/logger.ts
+++ b/src/util/logger.ts
@@ -31,7 +31,8 @@ const logger: Logger = createLogger({
     format.colorize(),
     format.splat(),
     format.timestamp(),
-    format.printf(info => `${info.timestamp} ${info.level}: ${info.message}`)
+    format.simple()
+    // format.printf(info => `${info.timestamp} ${info.level}: ${info.message} Stacktrace: ${info.stack}`)
   ),
   transports: [
     new transports.Console({ level: logLevel }),

--- a/src/util/queries/asset_filter.ts
+++ b/src/util/queries/asset_filter.ts
@@ -1,7 +1,7 @@
 export function buildAssetFilter(code: string | null, issuer?: string | null, predicate?: string) {
   return `
     ${predicate || "asset"} ${code ? `@filter(eq(code, "${code}"))` : ""} {
-      ${issuer ? `issuer @filter(eq(id, "${issuer}"))` : ""}
+      ${issuer ? `issuer @filter(eq(account.id, "${issuer}"))` : ""}
     }
   `;
 }

--- a/src/util/types.ts
+++ b/src/util/types.ts
@@ -1,0 +1,1 @@
+export type AccountID = string;


### PR DESCRIPTION
Here is my attempt to ingest `manageOffer` operations as a pair of "trades" — linked nodes similar to payment in many ways. Single trade looks like this:

```
{
  trade # "empty" predicate for using `has`
  op.source
  op.destination
  trade.asset
  amount
  offer_id
  # not sure about naming here
  trade.counterpart {
    # it's a link to another trade with op.source and op.destination swapped,
    # asset is the second asset in the offer, offer_id is the same
  }
}
```

I am not sure, should we use `op` prefix? It's some sort of legacy leaked in 😅 

What do you think, guys?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/astroband/astrograph/122)
<!-- Reviewable:end -->
