### PR TITLE
Fetching transactions from Horizon

### DIFF
--- a/src/datasource/horizon.ts
+++ b/src/datasource/horizon.ts
@@ -44,20 +44,16 @@ export default class HorizonAPI extends RESTDataSource {
 
   public async getTransactions(
     limit: number,
-    order?: "asc" | "desc",
+    order: "asc" | "desc" = "desc",
     cursor?: string
   ): Promise<IHorizonTransactionData[]> {
-    let path = `transactions?limit=${limit}`;
+    const params: { limit: number; order: string; cursor?: string } = { limit, order };
 
     if (cursor) {
-      path = path + `&cursor=${cursor}`;
+      params.cursor = cursor;
     }
 
-    if (order) {
-      path = path + `&order=${order}`;
-    }
-
-    const response = await this.get(path);
+    const response = await this.get("transactions", params);
 
     response._embedded.records.forEach((record: any) => {
       delete record._links;

--- a/src/datasource/horizon.ts
+++ b/src/datasource/horizon.ts
@@ -31,7 +31,7 @@ export default class HorizonAPI extends RESTDataSource {
     return data._embedded.records;
   }
 
-  public async getTransactions(transactionIds: string[]): Promise<IHorizonTransactionData[]> {
+  public async getTransactionsByIds(transactionIds: string[]): Promise<IHorizonTransactionData[]> {
     const promises = transactionIds.map(id => this.get(`transactions/${id}`));
 
     return Promise.all(promises).then(responses => {
@@ -40,5 +40,29 @@ export default class HorizonAPI extends RESTDataSource {
       });
       return responses;
     });
+  }
+
+  public async getTransactions(
+    limit: number,
+    order?: "asc" | "desc",
+    cursor?: string
+  ): Promise<IHorizonTransactionData[]> {
+    let path = `transactions?limit=${limit}`;
+
+    if (cursor) {
+      path = path + `&cursor=${cursor}`;
+    }
+
+    if (order) {
+      path = path + `&order=${order}`;
+    }
+
+    const response = await this.get(path);
+
+    response._embedded.records.forEach((record: any) => {
+      delete record._links;
+    });
+
+    return response._embedded.records;
   }
 }

--- a/src/datasource/horizon.ts
+++ b/src/datasource/horizon.ts
@@ -1,5 +1,5 @@
 import { RESTDataSource } from "apollo-datasource-rest";
-import { IHorizonOperationData } from "./types";
+import { IHorizonOperationData, IHorizonTransactionData } from "./types";
 
 export type OperationsParent = "transaction" | "account" | "ledger";
 
@@ -29,5 +29,16 @@ export default class HorizonAPI extends RESTDataSource {
     });
 
     return data._embedded.records;
+  }
+
+  public async getTransactions(transactionIds: string[]): Promise<IHorizonTransactionData[]> {
+    const promises = transactionIds.map(id => this.get(`transactions/${id}`));
+
+    return Promise.all(promises).then(responses => {
+      responses.forEach((record: IHorizonTransactionData & { _links: object }) => {
+        delete record._links;
+      });
+      return responses;
+    });
   }
 }

--- a/src/datasource/types.ts
+++ b/src/datasource/types.ts
@@ -126,6 +126,7 @@ export type IHorizonOperationData = IPaymentOperationData &
 
 export interface IHorizonTransactionData {
   id: string;
+  paging_token: string;
   successful: boolean;
   ledger: number;
   created_at: string;

--- a/src/datasource/types.ts
+++ b/src/datasource/types.ts
@@ -1,3 +1,4 @@
+import { MemoHash, MemoID, MemoNone, MemoReturn, MemoText } from "stellar-sdk";
 import { AccountID } from "../model/account_id";
 import { AssetCode } from "../model/asset_code";
 
@@ -122,3 +123,16 @@ export type IHorizonOperationData = IPaymentOperationData &
   IManageDataOperationData &
   IManageOfferOperationData &
   IPathPaymentOperationData;
+
+export interface IHorizonTransactionData {
+  id: string;
+  successful: boolean;
+  ledger: number;
+  created_at: string;
+  source_account: AccountID;
+  envelope_xdr: string;
+  result_xdr: string;
+  result_meta_xdr: string;
+  fee_meta_xdr: string;
+  memo_type: typeof MemoNone | typeof MemoID | typeof MemoHash | typeof MemoReturn | typeof MemoText;
+}

--- a/src/model/index.ts
+++ b/src/model/index.ts
@@ -1,4 +1,5 @@
 export * from "./account";
+export * from "./account_id";
 export * from "./account_thresholds";
 export * from "./account_flags";
 export * from "./account_values";

--- a/src/model/transaction.ts
+++ b/src/model/transaction.ts
@@ -7,7 +7,7 @@ export interface ITimeBounds {
 
 export interface ITransaction {
   id: string;
-  index?: number;
+  index: number;
   ledgerSeq: number;
   memo?: Memo;
   feeAmount: string;
@@ -20,7 +20,7 @@ export interface ITransaction {
 
 export class Transaction implements ITransaction {
   public id: string;
-  public index?: number;
+  public index: number;
   public ledgerSeq: number;
   public memo?: Memo;
   public feeAmount: string;

--- a/src/model/transaction.ts
+++ b/src/model/transaction.ts
@@ -8,7 +8,6 @@ export interface ITimeBounds {
 export interface ITransaction {
   id: string;
   ledgerSeq: number;
-  index: number;
   memo?: Memo;
   feeAmount: string;
   sourceAccount: string;
@@ -21,7 +20,6 @@ export interface ITransaction {
 export class Transaction implements ITransaction {
   public id: string;
   public ledgerSeq: number;
-  public index: number;
   public memo?: Memo;
   public feeAmount: string;
   public sourceAccount: string;
@@ -33,7 +31,6 @@ export class Transaction implements ITransaction {
   constructor(data: ITransaction) {
     this.id = data.id;
     this.ledgerSeq = data.ledgerSeq;
-    this.index = data.index;
     this.memo = data.memo;
     this.feeAmount = data.feeAmount;
     this.sourceAccount = data.sourceAccount;

--- a/src/model/transaction.ts
+++ b/src/model/transaction.ts
@@ -7,6 +7,7 @@ export interface ITimeBounds {
 
 export interface ITransaction {
   id: string;
+  index?: number;
   ledgerSeq: number;
   memo?: Memo;
   feeAmount: string;
@@ -19,6 +20,7 @@ export interface ITransaction {
 
 export class Transaction implements ITransaction {
   public id: string;
+  public index?: number;
   public ledgerSeq: number;
   public memo?: Memo;
   public feeAmount: string;
@@ -30,6 +32,7 @@ export class Transaction implements ITransaction {
 
   constructor(data: ITransaction) {
     this.id = data.id;
+    this.index = data.index;
     this.ledgerSeq = data.ledgerSeq;
     this.memo = data.memo;
     this.feeAmount = data.feeAmount;

--- a/src/schema/index.ts
+++ b/src/schema/index.ts
@@ -3,10 +3,11 @@ import { makeExecutableSchema, mergeSchemas } from "apollo-server";
 import { typeDefs as accountsTypeDefs } from "./accounts";
 import { typeDefs as horizonTypeDefs } from "./horizon";
 import resolvers from "./resolvers";
+import { typeDefs as transactionsTypeDefs } from "./transactions";
 import { typeDefs } from "./type_defs";
 
 const schema = makeExecutableSchema({
-  typeDefs: [typeDefs, horizonTypeDefs, accountsTypeDefs],
+  typeDefs: [typeDefs, horizonTypeDefs, accountsTypeDefs, transactionsTypeDefs],
   resolverValidationOptions: { requireResolversForResolveType: false }
 });
 

--- a/src/schema/resolvers/transaction.ts
+++ b/src/schema/resolvers/transaction.ts
@@ -1,4 +1,5 @@
-import { db } from "../../database";
+import { HorizonTransactionData } from "../../datasource/types";
+import { TransactionWithXDRFactory } from "../../model/factories";
 import { ledgerResolver, memoResolver } from "./util";
 
 export default {
@@ -7,11 +8,13 @@ export default {
     memo: memoResolver
   },
   Query: {
-    transaction(root: any, args: any, ctx: any, info: any) {
-      return db.transactions.findByID(args.id);
+    async transaction(root: any, args: any, ctx: any, info: any) {
+      const records = await ctx.dataSources.horizon.getTransactions([args.id]);
+      return TransactionWithXDRFactory.fromHorizon(records[0]);
     },
-    transactions(root: any, args: any, ctx: any, info: any) {
-      return db.transactions.findAllByID(args.id);
+    async transactions(root: any, args: any, ctx: any, info: any) {
+      const records = await ctx.dataSources.horizon.getTransactions(args.ids);
+      return records.map((tx: HorizonTransactionData) => TransactionWithXDRFactory.fromHorizon(tx));
     }
   }
 };

--- a/src/schema/resolvers/transaction.ts
+++ b/src/schema/resolvers/transaction.ts
@@ -1,4 +1,5 @@
 import { IHorizonTransactionData } from "../../datasource/types";
+import { Transaction } from "../../model";
 import { TransactionWithXDRFactory } from "../../model/factories";
 import { ledgerResolver, memoResolver } from "./util";
 
@@ -26,15 +27,19 @@ export default {
         records = records.reverse();
       }
 
+      const edges = records.map((record: IHorizonTransactionData) => {
+        return {
+          node: TransactionWithXDRFactory.fromHorizon(record),
+          cursor: record.paging_token
+        };
+      });
+
       return {
-        edges: records.map((record: IHorizonTransactionData) => {
-          return {
-            node: TransactionWithXDRFactory.fromHorizon(record),
-            cursor: record.paging_token
-          };
-        }),
+        nodes: edges.map((edge: { cursor: string; node: Transaction }) => edge.node),
+        edges,
         pageInfo: {
-          endCursor: records[records.length - 1].paging_token
+          startCursor: records.length !== 0 ? records[0].paging_token : null,
+          endCursor: records.length !== 0 ? records[records.length - 1].paging_token : null
         }
       };
     }

--- a/src/schema/resolvers/transaction.ts
+++ b/src/schema/resolvers/transaction.ts
@@ -1,4 +1,4 @@
-import { HorizonTransactionData } from "../../datasource/types";
+import { IHorizonTransactionData } from "../../datasource/types";
 import { TransactionWithXDRFactory } from "../../model/factories";
 import { ledgerResolver, memoResolver } from "./util";
 
@@ -14,7 +14,7 @@ export default {
     },
     async transactions(root: any, args: any, ctx: any, info: any) {
       const records = await ctx.dataSources.horizon.getTransactions(args.ids);
-      return records.map((tx: HorizonTransactionData) => TransactionWithXDRFactory.fromHorizon(tx));
+      return records.map((tx: IHorizonTransactionData) => TransactionWithXDRFactory.fromHorizon(tx));
     }
   }
 };

--- a/src/schema/resolvers/transaction.ts
+++ b/src/schema/resolvers/transaction.ts
@@ -9,12 +9,23 @@ export default {
   },
   Query: {
     async transaction(root: any, args: any, ctx: any, info: any) {
-      const records = await ctx.dataSources.horizon.getTransactions([args.id]);
+      const records = await ctx.dataSources.horizon.getTransactionsById([args.id]);
       return TransactionWithXDRFactory.fromHorizon(records[0]);
     },
     async transactions(root: any, args: any, ctx: any, info: any) {
-      const records = await ctx.dataSources.horizon.getTransactions(args.ids);
-      return records.map((tx: IHorizonTransactionData) => TransactionWithXDRFactory.fromHorizon(tx));
+      const records = await ctx.dataSources.horizon.getTransactions(args.first, args.order || "desc", args.after);
+
+      return {
+        edges: records.map((record: IHorizonTransactionData) => {
+          return {
+            node: TransactionWithXDRFactory.fromHorizon(record),
+            cursor: record.paging_token
+          };
+        }),
+        pageInfo: {
+          endCursor: records[records.length - 1].paging_token
+        }
+      };
     }
   }
 };

--- a/src/schema/resolvers/transaction.ts
+++ b/src/schema/resolvers/transaction.ts
@@ -1,5 +1,4 @@
 import { IHorizonTransactionData } from "../../datasource/types";
-import { Transaction } from "../../model";
 import { TransactionWithXDRFactory } from "../../model/factories";
 import { ledgerResolver, memoResolver } from "./util";
 
@@ -15,29 +14,25 @@ export default {
     },
     async transactions(root: any, args: any, ctx: any, info: any) {
       const { first, last, after, before } = args;
-      const records = await ctx.dataSources.horizon.getTransactions(
+      let records = await ctx.dataSources.horizon.getTransactions(
         first || last,
         last ? "asc" : "desc",
         last ? before : after
       );
 
-      return {
-        edges: records
-          .map((record: IHorizonTransactionData) => {
-            return {
-              node: TransactionWithXDRFactory.fromHorizon(record),
-              cursor: record.paging_token
-            };
-          })
-          .sort((a: { node: Transaction }, b: { node: Transaction }) => {
-            // we must keep descending ordering, because Horizon doesn't do it,
-            // when you request the previous page
-            if (b.node.ledgerSeq !== a.node.ledgerSeq) {
-              return b.node.ledgerSeq - a.node.ledgerSeq;
-            }
+      // we must keep descending ordering, because Horizon doesn't do it,
+      // when you request the previous page
+      if (last) {
+        records = records.reverse();
+      }
 
-            return b.node.index - a.node.index;
-          }),
+      return {
+        edges: records.map((record: IHorizonTransactionData) => {
+          return {
+            node: TransactionWithXDRFactory.fromHorizon(record),
+            cursor: record.paging_token
+          };
+        }),
         pageInfo: {
           endCursor: records[records.length - 1].paging_token
         }

--- a/src/schema/resolvers/transaction.ts
+++ b/src/schema/resolvers/transaction.ts
@@ -1,10 +1,14 @@
+import { db } from "../../database";
 import { IHorizonTransactionData } from "../../datasource/types";
-import { Transaction } from "../../model";
+import { Account, Transaction } from "../../model";
 import { TransactionWithXDRFactory } from "../../model/factories";
-import { ledgerResolver, memoResolver, operationsResolver } from "./util";
+import { createBatchResolver, ledgerResolver, memoResolver, operationsResolver } from "./util";
 
 export default {
   Transaction: {
+    sourceAccount: createBatchResolver<Transaction, Account>((source: any) => {
+      return db.accounts.findAllByIDs(source.map((obj: Transaction) => obj.sourceAccount));
+    }),
     ledger: ledgerResolver,
     memo: memoResolver,
     operations: operationsResolver

--- a/src/schema/resolvers/transaction.ts
+++ b/src/schema/resolvers/transaction.ts
@@ -1,12 +1,13 @@
 import { IHorizonTransactionData } from "../../datasource/types";
 import { Transaction } from "../../model";
 import { TransactionWithXDRFactory } from "../../model/factories";
-import { ledgerResolver, memoResolver } from "./util";
+import { ledgerResolver, memoResolver, operationsResolver } from "./util";
 
 export default {
   Transaction: {
     ledger: ledgerResolver,
-    memo: memoResolver
+    memo: memoResolver,
+    operations: operationsResolver
   },
   Query: {
     async transaction(root: any, args: any, ctx: any, info: any) {

--- a/src/schema/resolvers/util.ts
+++ b/src/schema/resolvers/util.ts
@@ -83,7 +83,7 @@ export async function operationsResolver(obj: any, args: any, ctx: any) {
   });
 
   return {
-    nodes: edges.map((edge: { node: Operation, cursor: string }) => edge.node),
+    nodes: edges.map((edge: { node: Operation; cursor: string }) => edge.node),
     edges,
     pageInfo: {
       startCursor: data.length !== 0 ? data[0].paging_token : null,

--- a/src/schema/transactions.ts
+++ b/src/schema/transactions.ts
@@ -16,19 +16,20 @@ export const typeDefs = gql`
     resultCode: Int!
   }
 
-  type TransactionsConnection {
+  type TransactionConnection {
     pageInfo: PageInfo!
-    edges: [TransactionsEdge]
+    nodes: [Transaction]
+    edges: [TransactionEdge]
   }
 
-  type TransactionsEdge {
+  type TransactionEdge {
     cursor: String!
     node: Transaction
   }
 
   extend type Query {
     transaction(id: TransactionHash!): Transaction
-    transactions(first: Int, after: String, last: Int, before: String): TransactionsConnection
+    transactions(first: Int, after: String, last: Int, before: String): TransactionConnection
   }
 
 `;

--- a/src/schema/transactions.ts
+++ b/src/schema/transactions.ts
@@ -8,10 +8,10 @@ export const typeDefs = gql`
     ledger: Ledger!
     index: Int!
     memo: Memo
-    feeAmount: String!
+    feeAmount: Int!
     sourceAccount: AccountID!
     timeBounds: TimeBounds
-    feeCharged: String!
+    feeCharged: Int!
     success: Boolean!
     resultCode: Int!
     operations(first: Int, after: String, last: Int, before: String): OperationConnection

--- a/src/schema/transactions.ts
+++ b/src/schema/transactions.ts
@@ -28,7 +28,7 @@ export const typeDefs = gql`
 
   extend type Query {
     transaction(id: TransactionHash!): Transaction
-    transactions(first: Int!, order: Order, after: String): TransactionsConnection
+    transactions(first: Int, after: String, last: Int, before: String): TransactionsConnection
   }
 
 `;

--- a/src/schema/transactions.ts
+++ b/src/schema/transactions.ts
@@ -1,0 +1,34 @@
+import { gql } from "apollo-server";
+
+export const typeDefs = gql`
+  scalar TransactionHash
+
+  type Transaction {
+    id: TransactionHash!
+    ledger: Ledger!
+    index: Int!
+    memo: Memo
+    feeAmount: String!
+    sourceAccount: AccountID!
+    timeBounds: TimeBounds
+    feeCharged: String!
+    success: Boolean!
+    resultCode: Int!
+  }
+
+  type TransactionsConnection {
+    pageInfo: PageInfo!
+    edges: [TransactionsEdge]
+  }
+
+  type TransactionsEdge {
+    cursor: String!
+    node: Transaction
+  }
+
+  extend type Query {
+    transaction(id: TransactionHash!): Transaction
+    transactions(first: Int!, order: Order, after: String): TransactionsConnection
+  }
+
+`;

--- a/src/schema/transactions.ts
+++ b/src/schema/transactions.ts
@@ -14,6 +14,7 @@ export const typeDefs = gql`
     feeCharged: String!
     success: Boolean!
     resultCode: Int!
+    operations(first: Int, after: String, last: Int, before: String): OperationConnection
   }
 
   type TransactionConnection {

--- a/src/schema/transactions.ts
+++ b/src/schema/transactions.ts
@@ -9,7 +9,7 @@ export const typeDefs = gql`
     index: Int!
     memo: Memo
     feeAmount: Int!
-    sourceAccount: AccountID!
+    sourceAccount: Account!
     timeBounds: TimeBounds
     feeCharged: Int!
     success: Boolean!

--- a/src/schema/type_defs.ts
+++ b/src/schema/type_defs.ts
@@ -13,15 +13,6 @@ export const typeDefs = gql`
   }
 
   type PageInfo {
-    endCursor: String!
-  }
-
-  enum Order {
-    desc
-    asc
-  }
-
-  type PageInfo {
     startCursor: String
     endCursor: String
   }

--- a/src/schema/type_defs.ts
+++ b/src/schema/type_defs.ts
@@ -6,6 +6,7 @@ export const typeDefs = gql`
   scalar TimeBounds
   scalar MemoValue
   scalar DateTime
+  scalar TransactionHash
 
   enum Order {
     desc
@@ -171,7 +172,7 @@ export const typeDefs = gql`
     index: Int!
     memo: Memo
     feeAmount: String!
-    sourceAccount: String!
+    sourceAccount: AccountID!
     timeBounds: TimeBounds
     feeCharged: String!
     success: Boolean!
@@ -207,8 +208,8 @@ export const typeDefs = gql`
     trustLines(id: AccountID!): [TrustLine]
     ledger(seq: Int!): Ledger!
     ledgers(seq: [Int!]): [Ledger]!
-    transaction(id: String!): Transaction
-    transactions(id: [String!]): [Transaction]
+    transaction(id: TransactionHash!): Transaction
+    transactions(ids: [TransactionHash!]): [Transaction]
     offers(
       seller: AccountID
       selling: AssetInput

--- a/src/schema/type_defs.ts
+++ b/src/schema/type_defs.ts
@@ -6,7 +6,15 @@ export const typeDefs = gql`
   scalar TimeBounds
   scalar MemoValue
   scalar DateTime
-  scalar TransactionHash
+
+  enum Order {
+    desc
+    asc
+  }
+
+  type PageInfo {
+    endCursor: String!
+  }
 
   enum Order {
     desc
@@ -166,19 +174,6 @@ export const typeDefs = gql`
     values: OfferValues
   }
 
-  type Transaction {
-    id: String!
-    ledger: Ledger!
-    index: Int!
-    memo: Memo
-    feeAmount: String!
-    sourceAccount: AccountID!
-    timeBounds: TimeBounds
-    feeCharged: String!
-    success: Boolean!
-    resultCode: Int!
-  }
-
   input AssetInput {
     code: AssetCode
     issuer: AccountID
@@ -208,8 +203,6 @@ export const typeDefs = gql`
     trustLines(id: AccountID!): [TrustLine]
     ledger(seq: Int!): Ledger!
     ledgers(seq: [Int!]): [Ledger]!
-    transaction(id: TransactionHash!): Transaction
-    transactions(ids: [TransactionHash!]): [Transaction]
     offers(
       seller: AccountID
       selling: AssetInput

--- a/src/storage/builders/operation.ts
+++ b/src/storage/builders/operation.ts
@@ -35,7 +35,7 @@ export class OperationBuilder extends Builder {
     super();
 
     this.seq = tx.ledgerSeq;
-    this.index = tx.index!;
+    this.index = tx.index;
     this.current = NQuad.blank(OperationBuilder.key(tx.ledgerSeq, this.index, n));
 
     if (n > 0) {

--- a/src/storage/builders/operation.ts
+++ b/src/storage/builders/operation.ts
@@ -35,11 +35,11 @@ export class OperationBuilder extends Builder {
     super();
 
     this.seq = tx.ledgerSeq;
-    this.index = tx.index;
+    this.index = tx.index!;
     this.current = NQuad.blank(OperationBuilder.key(tx.ledgerSeq, this.index, n));
 
     if (n > 0) {
-      this.prev = NQuad.blank(OperationBuilder.key(tx.ledgerSeq, tx.index, n - 1));
+      this.prev = NQuad.blank(OperationBuilder.key(tx.ledgerSeq, this.index, n - 1));
     }
 
     this.xdr = tx.operationsXDR[n];
@@ -94,7 +94,7 @@ export class OperationBuilder extends Builder {
   }
 
   protected pushRoot() {
-    const tx = TransactionBuilder.keyNQuad(this.tx.ledgerSeq, this.tx.index);
+    const tx = TransactionBuilder.keyNQuad(this.tx.ledgerSeq, this.index);
 
     const kind = this.xdr.body().switch().name;
 

--- a/src/storage/builders/transaction.ts
+++ b/src/storage/builders/transaction.ts
@@ -20,10 +20,10 @@ export class TransactionBuilder extends Builder {
     super();
 
     this.seq = tx.ledgerSeq;
-    this.current = TransactionBuilder.keyNQuad(tx.ledgerSeq, tx.index);
+    this.current = TransactionBuilder.keyNQuad(tx.ledgerSeq, tx.index!);
 
-    if (tx.index > 0) {
-      this.prev = TransactionBuilder.keyNQuad(tx.ledgerSeq, tx.index - 1);
+    if (tx.index! > 0) {
+      this.prev = TransactionBuilder.keyNQuad(tx.ledgerSeq, tx.index! - 1);
     }
   }
 
@@ -31,8 +31,8 @@ export class TransactionBuilder extends Builder {
     const v = {
       key: this.current.value,
       "tx.id": this.tx.id,
-      "tx.index": this.tx.index,
-      order: this.order(this.seq, this.tx.index),
+      "tx.index": this.tx.index!,
+      order: this.order(this.seq, this.tx.index!),
       fee_amount: this.tx.feeAmount,
       fee_charged: this.tx.feeCharged,
       success: this.tx.success,

--- a/src/storage/builders/transaction.ts
+++ b/src/storage/builders/transaction.ts
@@ -20,10 +20,10 @@ export class TransactionBuilder extends Builder {
     super();
 
     this.seq = tx.ledgerSeq;
-    this.current = TransactionBuilder.keyNQuad(tx.ledgerSeq, tx.index!);
+    this.current = TransactionBuilder.keyNQuad(tx.ledgerSeq, tx.index);
 
-    if (tx.index! > 0) {
-      this.prev = TransactionBuilder.keyNQuad(tx.ledgerSeq, tx.index! - 1);
+    if (tx.index > 0) {
+      this.prev = TransactionBuilder.keyNQuad(tx.ledgerSeq, tx.index - 1);
     }
   }
 
@@ -31,8 +31,8 @@ export class TransactionBuilder extends Builder {
     const v = {
       key: this.current.value,
       "tx.id": this.tx.id,
-      "tx.index": this.tx.index!,
-      order: this.order(this.seq, this.tx.index!),
+      "tx.index": this.tx.index,
+      order: this.order(this.seq, this.tx.index),
       fee_amount: this.tx.feeAmount,
       fee_charged: this.tx.feeCharged,
       success: this.tx.success,


### PR DESCRIPTION
Here is moving from serving transactions from the core database to using public Horizon

We've got one issue here: it seems that Horizon doesn't serve transaction's index. So I sacrificed it in our GraphQL schema. Unfortunately, it leads to some dirty hacks with the bang (`tx.index!`) in DGraph builders, because we rely on index there, and core database has it.

Do we have a more elegant solution?

And the more general questions:

1. do we need `transactions(ids: [TransactionHash!])` endpoint
1. should we add an endpoint for fetching all transactions with proper pagination?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/astroband/astrograph/127)
<!-- Reviewable:end -->
