### PR TITLE
Serve assets from issuer account

### DIFF
--- a/src/model/account.ts
+++ b/src/model/account.ts
@@ -1,9 +1,5 @@
-<<<<<<< HEAD
 import { BigNumber } from "bignumber.js";
-import { AccountFlags, AccountID, AccountThresholds, Signer } from "./";
-=======
 import { AccountID, AccountThresholds, Signer } from "./";
->>>>>>> Remove flags from Account
 
 export interface IAccountBase {
   id: string;

--- a/src/model/account.ts
+++ b/src/model/account.ts
@@ -1,5 +1,9 @@
+<<<<<<< HEAD
 import { BigNumber } from "bignumber.js";
 import { AccountFlags, AccountID, AccountThresholds, Signer } from "./";
+=======
+import { AccountID, AccountThresholds, Signer } from "./";
+>>>>>>> Remove flags from Account
 
 export interface IAccountBase {
   id: string;
@@ -9,7 +13,6 @@ export interface IAccountBase {
   inflationDestination: AccountID;
   homeDomain: string;
   thresholds: AccountThresholds;
-  flags: AccountFlags;
   signers?: Signer[];
 }
 
@@ -27,7 +30,6 @@ export class Account implements IAccount {
   public inflationDestination: AccountID;
   public homeDomain: string;
   public thresholds: AccountThresholds;
-  public flags: AccountFlags;
   public lastModified: number;
   public signers?: Signer[];
   public readonly sellingLiabilities: BigNumber;
@@ -42,7 +44,6 @@ export class Account implements IAccount {
     this.homeDomain = data.homeDomain;
     this.lastModified = data.lastModified;
     this.thresholds = data.thresholds;
-    this.flags = data.flags;
     this.signers = data.signers;
     this.sellingLiabilities = data.sellingLiabilities;
     this.buyingLiabilities = data.buyingLiabilities;

--- a/src/model/account_values.ts
+++ b/src/model/account_values.ts
@@ -1,5 +1,4 @@
 import { IAccountBase } from "./account";
-import { AccountFlags } from "./account_flags";
 import { AccountThresholds } from "./account_thresholds";
 import { Signer } from "./signer";
 
@@ -15,7 +14,6 @@ export class AccountValues implements IAccountValues {
   public inflationDestination: string;
   public homeDomain: string;
   public thresholds: AccountThresholds;
-  public flags: AccountFlags;
   public signers: Signer[];
 
   constructor(data: IAccountValues) {
@@ -26,7 +24,6 @@ export class AccountValues implements IAccountValues {
     this.inflationDestination = data.inflationDestination;
     this.homeDomain = data.homeDomain;
     this.thresholds = data.thresholds;
-    this.flags = data.flags;
 
     this.signers = Signer.sortArray(data.signers);
   }
@@ -44,10 +41,6 @@ export class AccountValues implements IAccountValues {
       if (this[attr] !== other[attr]) {
         changedAttrs.push(attr);
       }
-    }
-
-    if (!this.flags.equals(other.flags)) {
-      changedAttrs.push("flags");
     }
 
     if (!this.thresholds.equals(other.thresholds)) {

--- a/src/model/asset.ts
+++ b/src/model/asset.ts
@@ -36,7 +36,7 @@ export class Asset {
 
     const parsedFlags = AccountFlagsFactory.fromValue(data.flags);
     this.authRequired = parsedFlags.authRequired;
-    this.authRevocable = parsedFlags.authRevokable;
+    this.authRevocable = parsedFlags.authRevocable;
     this.authImmutable = parsedFlags.authImmutable;
   }
 

--- a/src/model/asset.ts
+++ b/src/model/asset.ts
@@ -34,8 +34,6 @@ export class Asset {
     this.unauthorizedHoldersCount = data.unauthorizedHoldersCount;
     this.lastModifiedIn = data.lastModifiedIn;
 
-    console.log(data);
-    console.log("flags", data.flags);
     const parsedFlags = AccountFlagsFactory.fromValue(data.flags);
     this.authRequired = parsedFlags.authRequired;
     this.authRevocable = parsedFlags.authRevokable;

--- a/src/model/asset.ts
+++ b/src/model/asset.ts
@@ -34,6 +34,8 @@ export class Asset {
     this.unauthorizedHoldersCount = data.unauthorizedHoldersCount;
     this.lastModifiedIn = data.lastModifiedIn;
 
+    console.log(data);
+    console.log("flags", data.flags);
     const parsedFlags = AccountFlagsFactory.fromValue(data.flags);
     this.authRequired = parsedFlags.authRequired;
     this.authRevocable = parsedFlags.authRevokable;

--- a/src/model/asset.ts
+++ b/src/model/asset.ts
@@ -1,0 +1,31 @@
+import { AccountID, AssetCode } from "./";
+
+interface IAssetData {
+  code: AssetCode;
+  issuer: AccountID;
+  totalSupply: string;
+  circulatingSupply: string;
+  holdersCount: string;
+  unauthorizedHoldersCount: string;
+  lastModifiedIn: number;
+}
+
+export class Asset {
+  public readonly code: AssetCode;
+  public readonly issuer: AccountID;
+  public readonly totalSupply: string;
+  public readonly circulatingSupply: string;
+  public readonly holdersCount: string;
+  public readonly unauthorizedHoldersCount: string;
+  public readonly lastModifiedIn: number;
+
+  constructor(data: IAssetData) {
+    this.code = data.code;
+    this.issuer = data.issuer;
+    this.totalSupply = data.totalSupply;
+    this.circulatingSupply = data.circulatingSupply;
+    this.holdersCount = data.holdersCount;
+    this.unauthorizedHoldersCount = data.unauthorizedHoldersCount;
+    this.lastModifiedIn = data.lastModifiedIn;
+  }
+}

--- a/src/model/asset.ts
+++ b/src/model/asset.ts
@@ -12,7 +12,7 @@ interface IAssetData {
 
 export class Asset {
   public readonly code: AssetCode;
-  public readonly issuer: AccountID;
+  public readonly issuer: AccountID | null;
   public readonly totalSupply: string;
   public readonly circulatingSupply: string;
   public readonly holdersCount: string;
@@ -27,5 +27,13 @@ export class Asset {
     this.holdersCount = data.holdersCount;
     this.unauthorizedHoldersCount = data.unauthorizedHoldersCount;
     this.lastModifiedIn = data.lastModifiedIn;
+  }
+
+  public get native(): boolean {
+    return this.code === "XLM" && this.issuer === null;
+  }
+
+  public get id() {
+    return this.native ? "native" : `${this.code}-${this.issuer}`;
   }
 }

--- a/src/model/asset.ts
+++ b/src/model/asset.ts
@@ -1,4 +1,5 @@
-import { AccountID, AssetCode } from "./";
+import { AccountID, AssetCode, IAssetInput } from "./";
+import { AccountFlagsFactory } from "./factories";
 
 interface IAssetData {
   code: AssetCode;
@@ -8,9 +9,11 @@ interface IAssetData {
   holdersCount: string;
   unauthorizedHoldersCount: string;
   lastModifiedIn: number;
+  flags: number;
 }
 
 export class Asset {
+  public static readonly NATIVE_ID = "native";
   public readonly code: AssetCode;
   public readonly issuer: AccountID | null;
   public readonly totalSupply: string;
@@ -18,6 +21,9 @@ export class Asset {
   public readonly holdersCount: string;
   public readonly unauthorizedHoldersCount: string;
   public readonly lastModifiedIn: number;
+  public readonly authRequired: boolean;
+  public readonly authRevocable: boolean;
+  public readonly authImmutable: boolean;
 
   constructor(data: IAssetData) {
     this.code = data.code;
@@ -27,6 +33,11 @@ export class Asset {
     this.holdersCount = data.holdersCount;
     this.unauthorizedHoldersCount = data.unauthorizedHoldersCount;
     this.lastModifiedIn = data.lastModifiedIn;
+
+    const parsedFlags = AccountFlagsFactory.fromValue(data.flags);
+    this.authRequired = parsedFlags.authRequired;
+    this.authRevocable = parsedFlags.authRevokable;
+    this.authImmutable = parsedFlags.authImmutable;
   }
 
   public get native(): boolean {
@@ -35,5 +46,19 @@ export class Asset {
 
   public get id() {
     return this.native ? "native" : `${this.code}-${this.issuer}`;
+  }
+
+  public get paging_token() {
+    return this.id;
+  }
+
+  public toInput(): IAssetInput {
+    const res: IAssetInput = { code: this.code };
+
+    if (this.issuer) {
+      res.issuer = this.issuer;
+    }
+
+    return res;
   }
 }

--- a/src/model/balance.ts
+++ b/src/model/balance.ts
@@ -1,5 +1,4 @@
 import { BigNumber } from "bignumber.js";
-import { Asset } from "stellar-sdk";
 import { AccountID, AssetID } from "./";
 
 export interface IBalanceBase {

--- a/src/model/balance.ts
+++ b/src/model/balance.ts
@@ -4,7 +4,7 @@ import { AccountID, AssetID } from "./";
 
 export interface IBalanceBase {
   account: AccountID;
-  asset: Asset;
+  asset: AssetID;
   limit: BigNumber;
   balance: BigNumber;
   authorized: boolean;
@@ -24,7 +24,7 @@ export class Balance implements IBalance {
   }
 
   public account: AccountID;
-  public asset: Asset;
+  public asset: AssetID;
   public readonly limit: BigNumber;
   public readonly balance: BigNumber;
   public authorized: boolean;
@@ -45,6 +45,6 @@ export class Balance implements IBalance {
   }
 
   public get paging_token() {
-    return Buffer.from(`${this.account}_${this.asset.toString()}_${this.balance}`).toString("base64");
+    return Buffer.from(`${this.account}_${this.asset}_${this.balance}`).toString("base64");
   }
 }

--- a/src/model/balance.ts
+++ b/src/model/balance.ts
@@ -45,6 +45,6 @@ export class Balance implements IBalance {
   }
 
   public get paging_token() {
-    return Buffer.from(`${this.account}_${this.asset}_${this.balance}`).toString("base64");
+    return Buffer.from(`${this.account}_${this.asset.toString()}_${this.balance}`).toString("base64");
   }
 }

--- a/src/model/balance_values.ts
+++ b/src/model/balance_values.ts
@@ -1,10 +1,9 @@
 import { BigNumber } from "bignumber.js";
-import { Asset } from "stellar-sdk";
-import { IBalanceBase } from "./balance";
+import { AssetID, IBalanceBase } from "./";
 
 export class BalanceValues implements IBalanceBase {
   public account: string;
-  public asset: Asset;
+  public asset: AssetID;
   public limit: BigNumber;
   public balance: BigNumber;
   public authorized: boolean;

--- a/src/model/factories/account_factory.ts
+++ b/src/model/factories/account_factory.ts
@@ -2,9 +2,7 @@ import { BigNumber } from "bignumber.js";
 import { VarArray } from "js-xdr";
 import { xdr } from "stellar-base";
 import { Account, IAccount } from "../account";
-import { SignerFactory } from "./";
-import { AccountFlagsFactory } from "./account_flags_factory";
-import { AccountThresholdsFactory } from "./account_thresholds_factory";
+import { AccountFlagsFactory, AccountThresholdsFactory, SignerFactory } from "./";
 
 export interface IAccountTableRow {
   accountid: string;

--- a/src/model/factories/account_factory.ts
+++ b/src/model/factories/account_factory.ts
@@ -2,7 +2,7 @@ import { BigNumber } from "bignumber.js";
 import { VarArray } from "js-xdr";
 import { xdr } from "stellar-base";
 import { Account, IAccount } from "../account";
-import { AccountFlagsFactory, AccountThresholdsFactory, SignerFactory } from "./";
+import { AccountThresholdsFactory, SignerFactory } from "./";
 
 export interface IAccountTableRow {
   accountid: string;
@@ -30,7 +30,6 @@ export class AccountFactory {
       homeDomain: row.homedomain,
       lastModified: row.lastmodified,
       thresholds: AccountThresholdsFactory.fromValue(row.thresholds),
-      flags: AccountFlagsFactory.fromValue(row.flags),
       sellingLiabilities: new BigNumber(row.sellingliabilities),
       buyingLiabilities: new BigNumber(row.buyingliabilities)
     };

--- a/src/model/factories/account_values_factory.ts
+++ b/src/model/factories/account_values_factory.ts
@@ -1,6 +1,4 @@
-import { AccountFlagsFactory } from "./account_flags_factory";
-import { AccountThresholdsFactory } from "./account_thresholds_factory";
-import { SignerFactory } from "./signer_factory";
+import { AccountThresholdsFactory, SignerFactory } from "./";
 
 import { AccountValues, IAccountValues } from "../";
 
@@ -22,7 +20,6 @@ export class AccountValuesFactory {
       inflationDestination: xdr.inflationDest() || null,
       homeDomain: xdr.homeDomain(),
       thresholds,
-      flags: AccountFlagsFactory.fromValue(xdr.flags()),
       signers
     };
 

--- a/src/model/factories/asset_factory.ts
+++ b/src/model/factories/asset_factory.ts
@@ -1,27 +1,46 @@
-import { Asset, xdr as XDR } from "stellar-base";
+import { Asset as StellarAsset, xdr as XDR } from "stellar-base";
+import { AccountID, Asset, AssetCode, AssetID, IAssetInput } from "../";
 import { HorizonAssetType } from "../../datasource/types";
-import { IAssetInput } from "../asset_input";
+
+export interface IAssetTableRow {
+  assetid: AssetID;
+  code: AssetCode;
+  issuer: AccountID;
+  total_supply: string;
+  circulating_supply: string;
+  holders_count: string;
+  unauthorized_holders_count: string;
+  last_activity: number;
+}
 
 export class AssetFactory {
-  public static fromDb(type: number, code: string, issuer: string) {
-    return type === XDR.AssetType.assetTypeNative().value ? Asset.native() : new Asset(code, issuer);
+  public static fromDb(row: IAssetTableRow) {
+    return new Asset({
+      code: row.code,
+      issuer: row.issuer,
+      totalSupply: row.total_supply,
+      circulatingSupply: row.circulating_supply,
+      holdersCount: row.holders_count,
+      unauthorizedHoldersCount: row.unauthorized_holders_count,
+      lastModifiedIn: row.last_activity
+    });
   }
 
   public static fromHorizon(type: HorizonAssetType, code?: string, issuer?: string) {
-    return type === "native" ? Asset.native() : new Asset(code, issuer);
+    return type === "native" ? StellarAsset.native() : new StellarAsset(code, issuer);
   }
 
   public static fromInput(arg: IAssetInput) {
     if (arg.issuer && arg.code) {
-      return new Asset(arg.code, arg.issuer);
+      return new StellarAsset(arg.code, arg.issuer);
     }
 
-    return Asset.native();
+    return StellarAsset.native();
   }
 
   public static fromId(id: string) {
     if (id === "native") {
-      return Asset.native();
+      return StellarAsset.native();
     }
 
     const [code, issuer] = id.split("-");
@@ -30,10 +49,10 @@ export class AssetFactory {
       throw new Error(`Invalid asset id "${id}"`);
     }
 
-    return new Asset(code, issuer);
+    return new StellarAsset(code, issuer);
   }
 
   public static fromXDR(xdr: any, encoding = "base64") {
-    return Asset.fromOperation(XDR.Asset.fromXDR(xdr, encoding));
+    return StellarAsset.fromOperation(XDR.Asset.fromXDR(xdr, encoding));
   }
 }

--- a/src/model/factories/asset_factory.ts
+++ b/src/model/factories/asset_factory.ts
@@ -1,4 +1,5 @@
-import { Asset as StellarAsset, xdr as XDR } from "stellar-base";
+import { xdr as XDR } from "stellar-base";
+import { Asset as StellarAsset } from "stellar-sdk";
 import { AccountID, Asset, AssetCode, AssetID, IAssetInput } from "../";
 import { HorizonAssetType } from "../../datasource/types";
 
@@ -28,8 +29,12 @@ export class AssetFactory {
     });
   }
 
+  public static fromTrustline(type: number, code: string, issuer: string): StellarAsset {
+    return type === XDR.AssetType.assetTypeNative().value ? StellarAsset.native() : new StellarAsset(code, issuer);
+  }
+
   public static fromHorizon(type: HorizonAssetType, code?: string, issuer?: string) {
-    return type === "native" ? StellarAsset.native() : new StellarAsset(code, issuer);
+    return type === "native" ? StellarAsset.native() : new StellarAsset(code!, issuer!);
   }
 
   public static fromInput(arg: IAssetInput) {

--- a/src/model/factories/asset_factory.ts
+++ b/src/model/factories/asset_factory.ts
@@ -14,7 +14,7 @@ export interface IAssetTableRow {
 }
 
 export class AssetFactory {
-  public static fromDb(row: IAssetTableRow) {
+  public static fromDb(row: IAssetTableRow): Asset {
     return new Asset({
       code: row.code,
       issuer: row.issuer,

--- a/src/model/factories/asset_factory.ts
+++ b/src/model/factories/asset_factory.ts
@@ -10,6 +10,7 @@ export interface IAssetTableRow {
   circulating_supply: string;
   holders_count: string;
   unauthorized_holders_count: string;
+  flags: number;
   last_activity: number;
 }
 
@@ -22,7 +23,8 @@ export class AssetFactory {
       circulatingSupply: row.circulating_supply,
       holdersCount: row.holders_count,
       unauthorizedHoldersCount: row.unauthorized_holders_count,
-      lastModifiedIn: row.last_activity
+      lastModifiedIn: row.last_activity,
+      flags: row.flags
     });
   }
 

--- a/src/model/factories/balance_factory.ts
+++ b/src/model/factories/balance_factory.ts
@@ -1,9 +1,8 @@
 import BigNumber from "bignumber.js";
-import { Asset, xdr as XDR } from "stellar-base";
+import { xdr as XDR } from "stellar-base";
 import { Account, Balance, IBalance } from "../";
 import { MAX_INT64 } from "../../util";
 import { getReservedBalance } from "../../util/base_reserve";
-import { AssetFactory } from "./";
 
 export interface ITrustLineTableRow {
   accountid: string;
@@ -28,7 +27,7 @@ export class BalanceFactory {
       balance,
       limit,
       lastModified: row.lastmodified,
-      asset: AssetFactory.fromDb(row.assettype, row.assetcode, row.issuer),
+      asset: `${row.assetcode}-${row.issuer}`,
       authorized: (row.flags & XDR.TrustLineFlags.authorizedFlag().value) > 0,
       spendableBalance: balance.minus(row.sellingliabilities || 0),
       receivableBalance: limit.minus(row.buyingliabilities || 0).minus(balance)
@@ -44,7 +43,7 @@ export class BalanceFactory {
 
     return new Balance({
       account: account.id,
-      asset: Asset.native(),
+      asset: "native",
       balance,
       limit,
       authorized: true,

--- a/src/model/factories/balance_values_factory.ts
+++ b/src/model/factories/balance_values_factory.ts
@@ -8,7 +8,7 @@ import { BalanceValues } from "../balance_values";
 export class BalanceValuesFactory {
   public static fromXDR(xdr: any): BalanceValues {
     return new BalanceValues({
-      asset: Asset.fromOperation(xdr.asset()),
+      asset: Asset.fromOperation(xdr.asset()).toString(),
       account: publicKeyFromXDR(xdr),
       balance: new BigNumber(xdr.balance().toString()),
       limit: new BigNumber(xdr.limit().toString()),
@@ -19,7 +19,7 @@ export class BalanceValuesFactory {
   public static fakeNativeFromXDR(xdr: any): BalanceValues {
     return new BalanceValues({
       account: publicKeyFromXDR(xdr),
-      asset: Asset.native(),
+      asset: "native",
       limit: new BigNumber(MAX_INT64),
       authorized: true,
       balance: new BigNumber(xdr.balance().toString())

--- a/src/model/index.ts
+++ b/src/model/index.ts
@@ -4,6 +4,8 @@ export * from "./account_thresholds";
 export * from "./account_flags";
 export * from "./account_values";
 export * from "./account_subscription_payload";
+export * from "./asset";
+export * from "./asset_code";
 export * from "./asset_id";
 export * from "./asset_input";
 export * from "./data_entry";

--- a/src/repo/assets.ts
+++ b/src/repo/assets.ts
@@ -1,8 +1,7 @@
 import { IDatabase } from "pg-promise";
 import squel from "squel";
-import { Asset } from "stellar-sdk";
-import { AssetID, Balance, IAssetInput } from "../model";
-import { AssetFactory, BalanceFactory } from "../model/factories";
+import { Asset, AssetID, Balance, IAssetInput } from "../model";
+import { AssetFactory, BalanceFactory, IAssetTableRow } from "../model/factories";
 import { PagingParams, parseCursorPagination, properlyOrdered, SortOrder } from "../util/paging";
 
 export default class AssetsRepo {
@@ -21,6 +20,22 @@ export default class AssetsRepo {
     const res = await this.db.oneOrNone(queryBuilder.toString());
 
     return res ? AssetFactory.fromDb(res) : null;
+  }
+
+  public async findAllByIDs(assetIds: AssetID[]) {
+    if (assetIds.length === 0) {
+      return [];
+    }
+
+    const queryBuilder = squel
+      .select()
+      .from("assets")
+      .where("assetid IN ?", assetIds);
+
+    const res = await this.db.manyOrNone<IAssetTableRow>(queryBuilder.toString());
+    const assets = res.map<Asset>(r => AssetFactory.fromDb(r));
+
+    return assetIds.map(id => assets.find(a => a.id === id) || null);
   }
 
   public async findAll(criteria: IAssetInput, paging: PagingParams) {

--- a/src/repo/assets.ts
+++ b/src/repo/assets.ts
@@ -4,7 +4,7 @@ import { Asset, AssetID, Balance, IAssetInput } from "../model";
 import { AssetFactory, BalanceFactory, IAssetTableRow } from "../model/factories";
 import { PagingParams, parseCursorPagination, properlyOrdered, SortOrder } from "../util/paging";
 
-const TABLE_NAME = "assets_materialized";
+const TABLE_NAME = "assets";
 
 export default class AssetsRepo {
   private db: IDatabase<any>;

--- a/src/repo/assets.ts
+++ b/src/repo/assets.ts
@@ -52,7 +52,7 @@ export default class AssetsRepo {
       .from(TABLE_NAME)
       .where("assetid != ?", Asset.NATIVE_ID)
       .order("assetid", order === SortOrder.ASC)
-      .limit(limit)
+      .limit(limit);
 
     if (criteria.code) {
       queryBuilder.where("code = ?", criteria.code);

--- a/src/repo/assets.ts
+++ b/src/repo/assets.ts
@@ -4,6 +4,8 @@ import { Asset, AssetID, Balance, IAssetInput } from "../model";
 import { AssetFactory, BalanceFactory, IAssetTableRow } from "../model/factories";
 import { PagingParams, parseCursorPagination, properlyOrdered, SortOrder } from "../util/paging";
 
+const TABLE_NAME = "assets_materialized";
+
 export default class AssetsRepo {
   private db: IDatabase<any>;
 
@@ -14,7 +16,7 @@ export default class AssetsRepo {
   public async findByID(assetId: AssetID) {
     const queryBuilder = squel
       .select()
-      .from("assets")
+      .from(TABLE_NAME)
       .where("assetid = ?", assetId);
 
     const res = await this.db.oneOrNone(queryBuilder.toString());
@@ -29,7 +31,7 @@ export default class AssetsRepo {
 
     const queryBuilder = squel
       .select()
-      .from("assets")
+      .from(TABLE_NAME)
       .where("assetid IN ?", assetIds);
 
     const res = await this.db.manyOrNone<IAssetTableRow>(queryBuilder.toString());
@@ -40,12 +42,17 @@ export default class AssetsRepo {
 
   public async findAll(criteria: IAssetInput, paging: PagingParams) {
     const { limit, cursor, order } = parseCursorPagination(paging);
+    // We skip lumens here for the sake of consistent pagination
+    // they have `native` as an id and pagination token so it will
+    // break intended alphanumeric ordering
+    // Anyway, it seems a rare case, when someone would need lumens in
+    // the aggregate list
     const queryBuilder = squel
       .select()
-      .from("assets")
-      .order("code")
+      .from(TABLE_NAME)
+      .where("assetid != ?", Asset.NATIVE_ID)
+      .order("assetid", order === SortOrder.ASC)
       .limit(limit)
-      .order("assetid", order === SortOrder.ASC);
 
     if (criteria.code) {
       queryBuilder.where("code = ?", criteria.code);
@@ -57,9 +64,9 @@ export default class AssetsRepo {
 
     if (cursor) {
       if (paging.after) {
-        queryBuilder.where("id < ?", paging.after);
+        queryBuilder.where("assetid > ?", paging.after);
       } else if (paging.before) {
-        queryBuilder.where("id > ?", paging.before);
+        queryBuilder.where("assetid < ?", paging.before);
       }
     }
 

--- a/src/schema/accounts.ts
+++ b/src/schema/accounts.ts
@@ -4,16 +4,6 @@ export const typeDefs = gql`
   "Represents the [public key](https://www.stellar.org/developers/guides/concepts/accounts.html#account-id) of the particular account"
   scalar AccountID
 
-  "Represents three flags, used by issuers of assets"
-  type AccountFlags {
-    "Requires the issuing account to give other accounts permission before they can hold the issuing account’s credit"
-    authRequired: Boolean!
-    "Allows the issuing account to revoke its credit held by other accounts"
-    authRevocable: Boolean!
-    "If this is set then none of the authorization flags can be set and the account can never be deleted"
-    authImmutable: Boolean!
-  }
-
   "Represents [thresholds](https://www.stellar.org/developers/guides/concepts/accounts.html#thresholds) for different access levels"
   type AccountThresholds {
     "The weight of the master key"
@@ -42,8 +32,6 @@ export const typeDefs = gql`
     homeDomain: String
     "Thresholds for different access levels this account set"
     thresholds: AccountThresholds!
-    "Flags used, by issuers of assets"
-    flags: AccountFlags!
     "[Signers](https://www.stellar.org/developers/guides/concepts/multi-sig.html) of the account"
     signers: [Signer]
     "Ledger, in which account was modified last time"
@@ -86,8 +74,6 @@ export const typeDefs = gql`
     homeDomain: String
     "Thresholds for different access levels this account set"
     thresholds: AccountThresholds!
-    "Flags used, by issuers of assets"
-    flags: AccountFlags!
     "[Signers](https://www.stellar.org/developers/guides/concepts/multi-sig.html) of the account"
     signers: [Signer]
   }

--- a/src/schema/accounts.ts
+++ b/src/schema/accounts.ts
@@ -50,6 +50,8 @@ export const typeDefs = gql`
     ledger: Ledger!
     "[Data entries](https://www.stellar.org/developers/guides/concepts/list-of-operations.html#manage-data), attached to the account"
     data: [DataEntry]
+    "All assets, issued by this account"
+    assets(first: Int, after: String, last: Int, before: String): AssetConnection
     "[Balances](https://www.stellar.org/developers/guides/concepts/assets.html#trustlines) of this account"
     balances: [Balance]
     "A list of [operations](https://www.stellar.org/developers/guides/concepts/operations.html) on the Stellar network that the account performed"

--- a/src/schema/assets.ts
+++ b/src/schema/assets.ts
@@ -10,7 +10,7 @@ export const typeDefs = gql`
   type Asset {
     "Whether this asset is [lumens](https://www.stellar.org/developers/guides/concepts/assets.html)"
     native: Boolean!
-    "Asset issuer's account"
+    "Asset issuer's account. It's \`null\` for native lumens"
     issuer: Account
     "Asset's code"
     code: AssetCode!
@@ -28,34 +28,16 @@ export const typeDefs = gql`
     balances(first: Int, last: Int, after: String, before: String): BalanceConnection
   }
 
-  "Represents single [asset](https://www.stellar.org/developers/guides/concepts/assets.html) on Stellar network with additional statistics, provided by Horizon"
-  type AssetWithInfo {
-    "Whether this asset is [lumens](https://www.stellar.org/developers/guides/concepts/assets.html)"
-    native: Boolean!
-    "Asset issuer's account"
-    issuer: Account
-    "Asset's code"
-    code: AssetCode!
-    "The number of units of credit issued"
-    amount: Float
-    "The number of accounts that: 1) trust this asset and 2) where if the asset has the auth_required flag then the account is authorized to hold the asset"
-    numAccounts: Int
-    "Asset's issuer account flags"
-    flags: AccountFlags
-    "All accounts that trust this asset, ordered by balance"
-    balances(first: Int, last: Int, after: String, before: String): BalanceConnection
-  }
-
   "A list of assets"
-  type AssetWithInfoConnection {
+  type AssetConnection {
     pageInfo: PageInfo!
-    nodes: [AssetWithInfo]
-    edges: [AssetWithInfoEdge]
+    nodes: [Asset]
+    edges: [AssetEdge]
   }
 
-  type AssetWithInfoEdge {
+  type AssetEdge {
     cursor: String!
-    node: AssetWithInfo
+    node: Asset
   }
 
   input AssetInput {
@@ -74,6 +56,6 @@ export const typeDefs = gql`
       after: String
       last: Int
       before: String
-    ): AssetWithInfoConnection
+    ): AssetConnection
   }
 `;

--- a/src/schema/assets.ts
+++ b/src/schema/assets.ts
@@ -24,6 +24,12 @@ export const typeDefs = gql`
     unauthorizedHoldersCount: Int!
     "Ledger this asset was last time modified in"
     lastModifiedIn: Ledger!
+    "Requires the issuing account to give other accounts permission before they can hold the issuing account’s credit"
+    authRequired: Boolean!
+    "Allows the issuing account to revoke its credit held by other accounts"
+    authRevokable: Boolean!
+    "If this is set then none of the authorization flags can be set and the account can never be deleted"
+    authImmutable: Boolean!
     "All accounts that trust this asset, ordered by balance"
     balances(first: Int, last: Int, after: String, before: String): BalanceConnection
   }
@@ -48,7 +54,7 @@ export const typeDefs = gql`
   type Query {
     "Get single asset"
     asset(id: AssetID): Asset
-    "Get list of assets"
+    "Get list of assets. Note: native XLM asset isn't included here"
     assets(
       code: AssetCode
       issuer: AccountID

--- a/src/schema/assets.ts
+++ b/src/schema/assets.ts
@@ -55,13 +55,6 @@ export const typeDefs = gql`
     "Get single asset"
     asset(id: AssetID): Asset
     "Get list of assets. Note: native XLM asset isn't included here"
-    assets(
-      code: AssetCode
-      issuer: AccountID
-      first: Int
-      after: String
-      last: Int
-      before: String
-    ): AssetConnection
+    assets(code: AssetCode, issuer: AccountID, first: Int, after: String, last: Int, before: String): AssetConnection
   }
 `;

--- a/src/schema/assets.ts
+++ b/src/schema/assets.ts
@@ -14,6 +14,16 @@ export const typeDefs = gql`
     issuer: Account
     "Asset's code"
     code: AssetCode!
+    "Sum of all asset holders balances"
+    totalSupply: String!
+    "Sum of only authorized holders balances"
+    circulatingSupply: String!
+    "Total number of asset holders"
+    holdersCount: Int!
+    "Total number of unathorized holders"
+    unauthorizedHoldersCount: Int!
+    "Ledger this asset was last time modified in"
+    lastModifiedIn: Ledger!
     "All accounts that trust this asset, ordered by balance"
     balances(first: Int, last: Int, after: String, before: String): BalanceConnection
   }

--- a/src/schema/assets.ts
+++ b/src/schema/assets.ts
@@ -27,7 +27,7 @@ export const typeDefs = gql`
     "Requires the issuing account to give other accounts permission before they can hold the issuing account’s credit"
     authRequired: Boolean!
     "Allows the issuing account to revoke its credit held by other accounts"
-    authRevokable: Boolean!
+    authRevocable: Boolean!
     "If this is set then none of the authorization flags can be set and the account can never be deleted"
     authImmutable: Boolean!
     "All accounts that trust this asset, ordered by balance"

--- a/src/schema/resolvers/account.ts
+++ b/src/schema/resolvers/account.ts
@@ -70,6 +70,10 @@ export default {
   Account: {
     homeDomain: (root: Account) => Buffer.from(root.homeDomain, "base64").toString(),
     reservedBalance: (root: Account) => toFloatAmountString(getReservedBalance(root.numSubentries)),
+    assets: async (root: Account, args: any) => {
+      const assets = await db.assets.findAll({ issuer: root.id }, args);
+      return makeConnection(assets);
+    },
     data: dataEntriesResolver,
     balances: balancesResolver,
     ledger: resolvers.ledger,

--- a/src/schema/resolvers/account.ts
+++ b/src/schema/resolvers/account.ts
@@ -106,9 +106,8 @@ export default {
     inflationDestination: resolvers.account
   },
   Query: {
-    account: async (root: any, args: any) => {
-      const acc = await db.accounts.findByID(args.id);
-      return acc;
+    account(root: any, args: any) {
+      return db.accounts.findByID(args.id);
     },
     accounts: async (root: any, args: any) => {
       const { ids, homeDomain, ...paging } = args;

--- a/src/schema/resolvers/asset.ts
+++ b/src/schema/resolvers/asset.ts
@@ -1,14 +1,13 @@
 import { db } from "../../database";
-import { IHorizonAssetData } from "../../datasource/types";
 import { IApolloContext } from "../../graphql_server";
 import { Asset, AssetID } from "../../model";
 import { toFloatAmountString } from "../../util/stellar";
 import * as resolvers from "./shared";
 import { makeConnection } from "./util";
 
-const holdersResolver = async (root: any, args: any, ctx: IApolloContext, info: any) => {
-  const asset = root.native ? Asset.native() : new Asset(root.code, root.issuer);
-  const balances = await db.assets.findHolders(asset, args);
+const holdersResolver = async (root: Asset, args: any, ctx: IApolloContext, info: any) => {
+  const balances = await db.assets.findHolders(root.toInput(), args);
+
   return makeConnection(balances);
 };
 
@@ -16,7 +15,10 @@ export default {
   Asset: {
     issuer: resolvers.account,
     lastModifiedIn: resolvers.ledger,
-    totalSupply: (asset: Asset) => toFloatAmountString(asset.totalSupply),
+    totalSupply: (asset: Asset) => {
+      console.log(asset);
+      return toFloatAmountString(asset.totalSupply);
+    },
     circulatingSupply: (asset: Asset) => toFloatAmountString(asset.circulatingSupply),
     balances: holdersResolver
   },
@@ -26,25 +28,12 @@ export default {
     },
     assets: async (root: any, args: any, ctx: IApolloContext, info: any) => {
       const { code, issuer } = args;
-      const records: IHorizonAssetData[] = await ctx.dataSources.assets.all(
+      const records = await db.assets.findAll(
         code || issuer ? { code, issuer } : {},
         args
       );
 
-      return makeConnection(records, (r: IHorizonAssetData) => {
-        return {
-          code: r.asset_code,
-          issuer: r.asset_issuer,
-          native: r.asset_type === "native",
-          amount: r.amount,
-          numAccounts: r.num_accounts,
-          flags: {
-            authRequired: r.flags.auth_required,
-            authRevocable: r.flags.auth_revocable,
-            authImmutable: r.flags.auth_immutable
-          }
-        };
-      });
+      return makeConnection(records);
     }
   }
 };

--- a/src/schema/resolvers/asset.ts
+++ b/src/schema/resolvers/asset.ts
@@ -20,7 +20,6 @@ export default {
     circulatingSupply: (asset: Asset) => toFloatAmountString(asset.circulatingSupply),
     balances: holdersResolver
   },
-  AssetWithInfo: { issuer: resolvers.account, balances: holdersResolver },
   Query: {
     asset: async (root: any, { id }: { id: AssetID }, ctx: IApolloContext, info: any) => {
       return db.assets.findByID(id);

--- a/src/schema/resolvers/asset.ts
+++ b/src/schema/resolvers/asset.ts
@@ -15,10 +15,7 @@ export default {
   Asset: {
     issuer: resolvers.account,
     lastModifiedIn: resolvers.ledger,
-    totalSupply: (asset: Asset) => {
-      console.log(asset);
-      return toFloatAmountString(asset.totalSupply);
-    },
+    totalSupply: (asset: Asset) => toFloatAmountString(asset.totalSupply),
     circulatingSupply: (asset: Asset) => toFloatAmountString(asset.circulatingSupply),
     balances: holdersResolver
   },
@@ -28,10 +25,7 @@ export default {
     },
     assets: async (root: any, args: any, ctx: IApolloContext, info: any) => {
       const { code, issuer } = args;
-      const records = await db.assets.findAll(
-        code || issuer ? { code, issuer } : {},
-        args
-      );
+      const records = await db.assets.findAll(code || issuer ? { code, issuer } : {}, args);
 
       return makeConnection(records);
     }

--- a/src/schema/resolvers/shared/asset.ts
+++ b/src/schema/resolvers/shared/asset.ts
@@ -19,7 +19,5 @@ export const asset = createBatchResolver<any, Asset[]>((source: any, args: any, 
 
   const ids: AssetID[] = source.map((s: any) => s[field]);
 
-  console.log(ids);
-
   return db.assets.findAllByIDs(ids);
 });

--- a/src/schema/resolvers/shared/asset.ts
+++ b/src/schema/resolvers/shared/asset.ts
@@ -1,17 +1,25 @@
 import { Asset } from "stellar-sdk";
+import { db } from "../../../database";
 import { IApolloContext } from "../../../graphql_server";
+import { AssetID } from "../../../model";
+import { createBatchResolver, onlyFieldsRequested } from "../util";
 
-export function asset(obj: any, args: any, ctx: IApolloContext, info: any) {
+export const asset = createBatchResolver<any, Asset[]>((source: any, args: any, ctx: IApolloContext, info: any) => {
   const field = info.fieldName;
-  const value = obj[field] as Asset;
 
-  const res = (a: Asset): any => {
-    return { code: a.getCode(), issuer: a.getIssuer(), native: a.isNative() };
-  };
-
-  if (Array.isArray(value)) {
-    return value.map(a => res(a));
+  if (onlyFieldsRequested(info, ["code", "issuer"])) {
+    return source.map((obj: any) => {
+      if (obj[field] === "native") {
+        return { code: "XLM", issuer: null };
+      }
+      const [code, issuer] = obj[field].split("-");
+      return { code, issuer };
+    });
   }
 
-  return res(value);
-}
+  const ids: AssetID[] = source.map((s: any) => s[field]);
+
+  console.log(ids);
+
+  return db.assets.findAllByIDs(ids);
+});

--- a/src/schema/resolvers/shared/asset.ts
+++ b/src/schema/resolvers/shared/asset.ts
@@ -1,23 +1,28 @@
-import { Asset } from "stellar-sdk";
 import { db } from "../../../database";
 import { IApolloContext } from "../../../graphql_server";
-import { AssetID } from "../../../model";
+import { Asset, AssetID } from "../../../model";
 import { createBatchResolver, onlyFieldsRequested } from "../util";
 
 export const asset = createBatchResolver<any, Asset[]>((source: any, args: any, ctx: IApolloContext, info: any) => {
   const field = info.fieldName;
 
-  if (onlyFieldsRequested(info, ["code", "issuer"])) {
+  if (onlyFieldsRequested(info, ["code", "issuer", "native"])) {
     return source.map((obj: any) => {
-      if (obj[field] === "native") {
-        return { code: "XLM", issuer: null };
+      // this trick will return asset id either `obj[field]`
+      // is instance of SDK Asset class, either it's already a
+      // string asset id
+      const assetId = obj[field].toString();
+
+      if (assetId === "native") {
+        return { code: "XLM", issuer: null, native: true };
       }
-      const [code, issuer] = obj[field].split("-");
-      return { code, issuer };
+
+      const [code, issuer] = assetId.split("-");
+      return { code, issuer, native: false };
     });
   }
 
-  const ids: AssetID[] = source.map((s: any) => s[field]);
+  const ids: AssetID[] = source.map((s: any) => s[field].toString());
 
   return db.assets.findAllByIDs(ids);
 });

--- a/src/schema/resolvers/shared/ledger.ts
+++ b/src/schema/resolvers/shared/ledger.ts
@@ -1,6 +1,6 @@
 import { Ledger } from "../../../model";
 
 export function ledger(obj: any) {
-  const seq = obj.lastModified || obj.ledgerSeq;
+  const seq = obj.lastModified || obj.lastModifiedIn || obj.ledgerSeq;
   return new Ledger(seq);
 }

--- a/src/schema/resolvers/util.ts
+++ b/src/schema/resolvers/util.ts
@@ -23,7 +23,7 @@ export function idOnlyRequested(info: any): boolean {
 }
 
 export function onlyFieldsRequested(info: any, fields: string[]): boolean {
-  const requestedFields = [...new Set(fieldsList(info))] // dedupe;
+  const requestedFields = [...new Set(fieldsList(info))]; // dedupe
 
   return JSON.stringify(requestedFields.sort()) === JSON.stringify(fields.sort());
 }

--- a/src/schema/resolvers/util.ts
+++ b/src/schema/resolvers/util.ts
@@ -22,6 +22,12 @@ export function idOnlyRequested(info: any): boolean {
   return false;
 }
 
+export function onlyFieldsRequested(info: any, fields: string[]): boolean {
+  const requestedFields = [...new Set(fieldsList(info))] // dedupe;
+
+  return JSON.stringify(requestedFields.sort()) === JSON.stringify(fields.sort());
+}
+
 export function makeConnection<T extends IWithPagingToken, R = T>(records: T[], nodeBuilder?: (r: T) => R) {
   const edges = records.map(record => {
     return {

--- a/tests/integration/__snapshots__/integration.test.ts.snap
+++ b/tests/integration/__snapshots__/integration.test.ts.snap
@@ -5,23 +5,9 @@ Object {
   "assets": Object {
     "nodes": Array [
       Object {
-        "code": "ZZZ",
+        "code": "KHL",
         "issuer": Object {
-          "id": "GCLCYDPGX7YBYMV627KV2GAXFEYYKJYZBCZEFVKELIHJ62SLKFAREUWH",
-        },
-        "native": false,
-      },
-      Object {
-        "code": "ZZZ",
-        "issuer": Object {
-          "id": "GBYMZE2O2CCLYVZKDBSE4SBWYSMFGYSAX3QN5KY4EV32ADEKVY5WIXWC",
-        },
-        "native": false,
-      },
-      Object {
-        "code": "ZZZ",
-        "issuer": Object {
-          "id": "GBKSCKCMFEIZSELRVTYO5XWGSEYURZY7AEV35MYW65DBS6FT6OHKP5IZ",
+          "id": "GBTVGCI5OYBGDMCNKYFVSETXK6TTOQ4DRJBAC5K2PUUNSVB24PPSQ26Q",
         },
         "native": false,
       },

--- a/tests/integration/__snapshots__/integration.test.ts.snap
+++ b/tests/integration/__snapshots__/integration.test.ts.snap
@@ -62,11 +62,6 @@ Object {
         "value": "test_value",
       },
     ],
-    "flags": Object {
-      "authImmutable": false,
-      "authRequired": false,
-      "authRevocable": false,
-    },
     "id": "GCVIRZIN4CGYY56CSL7RYAFHKQTGE34GIASZ2D4IGZGV3FDL622LPQZT",
     "inflationDestination": null,
     "ledger": Object {

--- a/tests/integration/integration_queries/assets.gql
+++ b/tests/integration/integration_queries/assets.gql
@@ -1,6 +1,7 @@
 query {
   assets(
-    code: "KHL"
+    code: "KHL",
+    first: 10
   ) {
     nodes {
       code

--- a/tests/integration/integration_queries/single_account_query.gql
+++ b/tests/integration/integration_queries/single_account_query.gql
@@ -10,11 +10,6 @@
         issuer { id }
       }
     }
-    flags {
-      authRequired
-      authRevocable
-      authImmutable
-    }
     thresholds {
       masterWeight
       low

--- a/tests/integration/test_db.sql
+++ b/tests/integration/test_db.sql
@@ -2,8 +2,8 @@
 -- PostgreSQL database dump
 --
 
--- Dumped from database version 9.6.10
--- Dumped by pg_dump version 9.6.10
+-- Dumped from database version 9.6.9
+-- Dumped by pg_dump version 9.6.9
 
 SET statement_timeout = 0;
 SET lock_timeout = 0;
@@ -15,77 +15,75 @@ SET check_function_bodies = false;
 SET client_min_messages = warning;
 SET row_security = off;
 
-DROP INDEX public.upgradehistbyseq;
-DROP INDEX public.signersaccount;
-DROP INDEX public.sellingissuerindex;
-DROP INDEX public.scpquorumsbyseq;
-DROP INDEX public.scpenvsbyseq;
-DROP INDEX public.priceindex;
-DROP INDEX public.ledgersbyseq;
-DROP INDEX public.histfeebyseq;
-DROP INDEX public.histbyseq;
-DROP INDEX public.buyingissuerindex;
-DROP INDEX public.accountbalances;
-ALTER TABLE ONLY public.upgradehistory DROP CONSTRAINT upgradehistory_pkey;
-ALTER TABLE ONLY public.txhistory DROP CONSTRAINT txhistory_pkey;
-ALTER TABLE ONLY public.txfeehistory DROP CONSTRAINT txfeehistory_pkey;
-ALTER TABLE ONLY public.trustlines DROP CONSTRAINT trustlines_pkey;
-ALTER TABLE ONLY public.storestate DROP CONSTRAINT storestate_pkey;
-ALTER TABLE ONLY public.signers DROP CONSTRAINT signers_pkey;
-ALTER TABLE ONLY public.scpquorums DROP CONSTRAINT scpquorums_pkey;
-ALTER TABLE ONLY public.pubsub DROP CONSTRAINT pubsub_pkey;
-ALTER TABLE ONLY public.publishqueue DROP CONSTRAINT publishqueue_pkey;
-ALTER TABLE ONLY public.peers DROP CONSTRAINT peers_pkey;
-ALTER TABLE ONLY public.offers DROP CONSTRAINT offers_pkey;
-ALTER TABLE ONLY public.ledgerheaders DROP CONSTRAINT ledgerheaders_pkey;
-ALTER TABLE ONLY public.ledgerheaders DROP CONSTRAINT ledgerheaders_ledgerseq_key;
-ALTER TABLE ONLY public.ban DROP CONSTRAINT ban_pkey;
-ALTER TABLE ONLY public.accounts DROP CONSTRAINT accounts_pkey;
-ALTER TABLE ONLY public.accountdata DROP CONSTRAINT accountdata_pkey;
-DROP TABLE public.upgradehistory;
-DROP TABLE public.txhistory;
-DROP TABLE public.txfeehistory;
-DROP TABLE public.storestate;
-DROP TABLE public.signers;
-DROP TABLE public.scpquorums;
-DROP TABLE public.scphistory;
-DROP TABLE public.pubsub;
-DROP TABLE public.publishqueue;
-DROP TABLE public.peers;
-DROP TABLE public.offers;
-DROP TABLE public.ledgerheaders;
-DROP TABLE public.ban;
-DROP VIEW public.assets;
-DROP TABLE public.trustlines;
-DROP TABLE public.accounts;
-DROP TABLE public.accountdata;
-DROP EXTENSION plpgsql;
-DROP SCHEMA public;
+DROP INDEX IF EXISTS public.upgradehistbyseq;
+DROP INDEX IF EXISTS public.signersaccount;
+DROP INDEX IF EXISTS public.sellingissuerindex;
+DROP INDEX IF EXISTS public.scpquorumsbyseq;
+DROP INDEX IF EXISTS public.scpenvsbyseq;
+DROP INDEX IF EXISTS public.priceindex;
+DROP INDEX IF EXISTS public.ledgersbyseq;
+DROP INDEX IF EXISTS public.histfeebyseq;
+DROP INDEX IF EXISTS public.histbyseq;
+DROP INDEX IF EXISTS public.buyingissuerindex;
+DROP INDEX IF EXISTS public.accountbalances;
+ALTER TABLE IF EXISTS ONLY public.upgradehistory DROP CONSTRAINT IF EXISTS upgradehistory_pkey;
+ALTER TABLE IF EXISTS ONLY public.txhistory DROP CONSTRAINT IF EXISTS txhistory_pkey;
+ALTER TABLE IF EXISTS ONLY public.txfeehistory DROP CONSTRAINT IF EXISTS txfeehistory_pkey;
+ALTER TABLE IF EXISTS ONLY public.trustlines DROP CONSTRAINT IF EXISTS trustlines_pkey;
+ALTER TABLE IF EXISTS ONLY public.storestate DROP CONSTRAINT IF EXISTS storestate_pkey;
+ALTER TABLE IF EXISTS ONLY public.signers DROP CONSTRAINT IF EXISTS signers_pkey;
+ALTER TABLE IF EXISTS ONLY public.scpquorums DROP CONSTRAINT IF EXISTS scpquorums_pkey;
+ALTER TABLE IF EXISTS ONLY public.pubsub DROP CONSTRAINT IF EXISTS pubsub_pkey;
+ALTER TABLE IF EXISTS ONLY public.publishqueue DROP CONSTRAINT IF EXISTS publishqueue_pkey;
+ALTER TABLE IF EXISTS ONLY public.peers DROP CONSTRAINT IF EXISTS peers_pkey;
+ALTER TABLE IF EXISTS ONLY public.offers DROP CONSTRAINT IF EXISTS offers_pkey;
+ALTER TABLE IF EXISTS ONLY public.ledgerheaders DROP CONSTRAINT IF EXISTS ledgerheaders_pkey;
+ALTER TABLE IF EXISTS ONLY public.ledgerheaders DROP CONSTRAINT IF EXISTS ledgerheaders_ledgerseq_key;
+ALTER TABLE IF EXISTS ONLY public.ban DROP CONSTRAINT IF EXISTS ban_pkey;
+ALTER TABLE IF EXISTS ONLY public.accounts DROP CONSTRAINT IF EXISTS accounts_pkey;
+ALTER TABLE IF EXISTS ONLY public.accountdata DROP CONSTRAINT IF EXISTS accountdata_pkey;
+DROP VIEW IF EXISTS public.assets;
+DROP TABLE IF EXISTS public.upgradehistory;
+DROP TABLE IF EXISTS public.txhistory;
+DROP TABLE IF EXISTS public.txfeehistory;
+DROP TABLE IF EXISTS public.trustlines;
+DROP TABLE IF EXISTS public.storestate;
+DROP TABLE IF EXISTS public.signers;
+DROP TABLE IF EXISTS public.scpquorums;
+DROP TABLE IF EXISTS public.scphistory;
+DROP TABLE IF EXISTS public.pubsub;
+DROP TABLE IF EXISTS public.publishqueue;
+DROP TABLE IF EXISTS public.peers;
+DROP TABLE IF EXISTS public.offers;
+DROP TABLE IF EXISTS public.ledgerheaders;
+DROP TABLE IF EXISTS public.ban;
+DROP TABLE IF EXISTS public.accounts;
+DROP TABLE IF EXISTS public.accountdata;
+DROP EXTENSION IF EXISTS plpgsql;
+DROP SCHEMA IF EXISTS public;
 --
--- Name: public; Type: SCHEMA; Schema: -; Owner: charlie
+-- Name: public; Type: SCHEMA; Schema: -; Owner: -
 --
 
 CREATE SCHEMA public;
 
 
-ALTER SCHEMA public OWNER TO charlie;
-
 --
--- Name: SCHEMA public; Type: COMMENT; Schema: -; Owner: charlie
+-- Name: SCHEMA public; Type: COMMENT; Schema: -; Owner: -
 --
 
 COMMENT ON SCHEMA public IS 'standard public schema';
 
 
 --
--- Name: plpgsql; Type: EXTENSION; Schema: -; Owner: 
+-- Name: plpgsql; Type: EXTENSION; Schema: -; Owner: -
 --
 
 CREATE EXTENSION IF NOT EXISTS plpgsql WITH SCHEMA pg_catalog;
 
 
 --
--- Name: EXTENSION plpgsql; Type: COMMENT; Schema: -; Owner: 
+-- Name: EXTENSION plpgsql; Type: COMMENT; Schema: -; Owner: -
 --
 
 COMMENT ON EXTENSION plpgsql IS 'PL/pgSQL procedural language';
@@ -96,7 +94,7 @@ SET default_tablespace = '';
 SET default_with_oids = false;
 
 --
--- Name: accountdata; Type: TABLE; Schema: public; Owner: charlie
+-- Name: accountdata; Type: TABLE; Schema: public; Owner: -
 --
 
 CREATE TABLE public.accountdata (
@@ -107,10 +105,8 @@ CREATE TABLE public.accountdata (
 );
 
 
-ALTER TABLE public.accountdata OWNER TO charlie;
-
 --
--- Name: accounts; Type: TABLE; Schema: public; Owner: charlie
+-- Name: accounts; Type: TABLE; Schema: public; Owner: -
 --
 
 CREATE TABLE public.accounts (
@@ -132,64 +128,8 @@ CREATE TABLE public.accounts (
 );
 
 
-ALTER TABLE public.accounts OWNER TO charlie;
-
 --
--- Name: trustlines; Type: TABLE; Schema: public; Owner: charlie
---
-
-CREATE TABLE public.trustlines (
-    accountid character varying(56) NOT NULL,
-    assettype integer NOT NULL,
-    issuer character varying(56) NOT NULL,
-    assetcode character varying(12) NOT NULL,
-    tlimit bigint NOT NULL,
-    balance bigint NOT NULL,
-    flags integer NOT NULL,
-    lastmodified integer NOT NULL,
-    buyingliabilities bigint,
-    sellingliabilities bigint,
-    CONSTRAINT trustlines_balance_check CHECK ((balance >= 0)),
-    CONSTRAINT trustlines_buyingliabilities_check CHECK ((buyingliabilities >= 0)),
-    CONSTRAINT trustlines_sellingliabilities_check CHECK ((sellingliabilities >= 0)),
-    CONSTRAINT trustlines_tlimit_check CHECK ((tlimit > 0))
-);
-
-
-ALTER TABLE public.trustlines OWNER TO charlie;
-
---
--- Name: assets; Type: VIEW; Schema: public; Owner: charlie
---
-
-CREATE VIEW public.assets AS
-( SELECT (((t.assetcode)::text || '-'::text) || (t.issuer)::text) AS assetid,
-    t.assetcode AS code,
-    t.issuer,
-    sum(t.balance) AS total_supply,
-    sum(t.balance) FILTER (WHERE (t.flags = 1)) AS circulating_supply,
-    count(t.accountid) AS holders_count,
-    count(t.accountid) FILTER (WHERE (t.flags = 0)) AS unauthorized_holders_count,
-    max(t.lastmodified) AS last_activity
-   FROM public.trustlines t
-  GROUP BY t.issuer, t.assetcode
-  ORDER BY (count(t.accountid)) DESC)
-UNION
- SELECT 'native'::text AS assetid,
-    'XLM'::character varying AS code,
-    NULL::character varying AS issuer,
-    sum(accounts.balance) AS total_supply,
-    sum(accounts.balance) AS circulating_supply,
-    count(*) AS holders_count,
-    0 AS unauthorized_holders_count,
-    max(accounts.lastmodified) AS last_activity
-   FROM public.accounts;
-
-
-ALTER TABLE public.assets OWNER TO charlie;
-
---
--- Name: ban; Type: TABLE; Schema: public; Owner: charlie
+-- Name: ban; Type: TABLE; Schema: public; Owner: -
 --
 
 CREATE TABLE public.ban (
@@ -197,10 +137,8 @@ CREATE TABLE public.ban (
 );
 
 
-ALTER TABLE public.ban OWNER TO charlie;
-
 --
--- Name: ledgerheaders; Type: TABLE; Schema: public; Owner: charlie
+-- Name: ledgerheaders; Type: TABLE; Schema: public; Owner: -
 --
 
 CREATE TABLE public.ledgerheaders (
@@ -215,10 +153,8 @@ CREATE TABLE public.ledgerheaders (
 );
 
 
-ALTER TABLE public.ledgerheaders OWNER TO charlie;
-
 --
--- Name: offers; Type: TABLE; Schema: public; Owner: charlie
+-- Name: offers; Type: TABLE; Schema: public; Owner: -
 --
 
 CREATE TABLE public.offers (
@@ -241,10 +177,8 @@ CREATE TABLE public.offers (
 );
 
 
-ALTER TABLE public.offers OWNER TO charlie;
-
 --
--- Name: peers; Type: TABLE; Schema: public; Owner: charlie
+-- Name: peers; Type: TABLE; Schema: public; Owner: -
 --
 
 CREATE TABLE public.peers (
@@ -258,10 +192,8 @@ CREATE TABLE public.peers (
 );
 
 
-ALTER TABLE public.peers OWNER TO charlie;
-
 --
--- Name: publishqueue; Type: TABLE; Schema: public; Owner: charlie
+-- Name: publishqueue; Type: TABLE; Schema: public; Owner: -
 --
 
 CREATE TABLE public.publishqueue (
@@ -270,10 +202,8 @@ CREATE TABLE public.publishqueue (
 );
 
 
-ALTER TABLE public.publishqueue OWNER TO charlie;
-
 --
--- Name: pubsub; Type: TABLE; Schema: public; Owner: charlie
+-- Name: pubsub; Type: TABLE; Schema: public; Owner: -
 --
 
 CREATE TABLE public.pubsub (
@@ -282,10 +212,8 @@ CREATE TABLE public.pubsub (
 );
 
 
-ALTER TABLE public.pubsub OWNER TO charlie;
-
 --
--- Name: scphistory; Type: TABLE; Schema: public; Owner: charlie
+-- Name: scphistory; Type: TABLE; Schema: public; Owner: -
 --
 
 CREATE TABLE public.scphistory (
@@ -296,10 +224,8 @@ CREATE TABLE public.scphistory (
 );
 
 
-ALTER TABLE public.scphistory OWNER TO charlie;
-
 --
--- Name: scpquorums; Type: TABLE; Schema: public; Owner: charlie
+-- Name: scpquorums; Type: TABLE; Schema: public; Owner: -
 --
 
 CREATE TABLE public.scpquorums (
@@ -310,10 +236,8 @@ CREATE TABLE public.scpquorums (
 );
 
 
-ALTER TABLE public.scpquorums OWNER TO charlie;
-
 --
--- Name: signers; Type: TABLE; Schema: public; Owner: charlie
+-- Name: signers; Type: TABLE; Schema: public; Owner: -
 --
 
 CREATE TABLE public.signers (
@@ -323,10 +247,8 @@ CREATE TABLE public.signers (
 );
 
 
-ALTER TABLE public.signers OWNER TO charlie;
-
 --
--- Name: storestate; Type: TABLE; Schema: public; Owner: charlie
+-- Name: storestate; Type: TABLE; Schema: public; Owner: -
 --
 
 CREATE TABLE public.storestate (
@@ -335,10 +257,30 @@ CREATE TABLE public.storestate (
 );
 
 
-ALTER TABLE public.storestate OWNER TO charlie;
+--
+-- Name: trustlines; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.trustlines (
+    accountid character varying(56) NOT NULL,
+    assettype integer NOT NULL,
+    issuer character varying(56) NOT NULL,
+    assetcode character varying(12) NOT NULL,
+    tlimit bigint NOT NULL,
+    balance bigint NOT NULL,
+    flags integer NOT NULL,
+    lastmodified integer NOT NULL,
+    buyingliabilities bigint,
+    sellingliabilities bigint,
+    CONSTRAINT trustlines_balance_check CHECK ((balance >= 0)),
+    CONSTRAINT trustlines_buyingliabilities_check CHECK ((buyingliabilities >= 0)),
+    CONSTRAINT trustlines_sellingliabilities_check CHECK ((sellingliabilities >= 0)),
+    CONSTRAINT trustlines_tlimit_check CHECK ((tlimit > 0))
+);
+
 
 --
--- Name: txfeehistory; Type: TABLE; Schema: public; Owner: charlie
+-- Name: txfeehistory; Type: TABLE; Schema: public; Owner: -
 --
 
 CREATE TABLE public.txfeehistory (
@@ -350,10 +292,8 @@ CREATE TABLE public.txfeehistory (
 );
 
 
-ALTER TABLE public.txfeehistory OWNER TO charlie;
-
 --
--- Name: txhistory; Type: TABLE; Schema: public; Owner: charlie
+-- Name: txhistory; Type: TABLE; Schema: public; Owner: -
 --
 
 CREATE TABLE public.txhistory (
@@ -367,10 +307,8 @@ CREATE TABLE public.txhistory (
 );
 
 
-ALTER TABLE public.txhistory OWNER TO charlie;
-
 --
--- Name: upgradehistory; Type: TABLE; Schema: public; Owner: charlie
+-- Name: upgradehistory; Type: TABLE; Schema: public; Owner: -
 --
 
 CREATE TABLE public.upgradehistory (
@@ -382,95 +320,93 @@ CREATE TABLE public.upgradehistory (
 );
 
 
-ALTER TABLE public.upgradehistory OWNER TO charlie;
-
 --
--- Data for Name: accountdata; Type: TABLE DATA; Schema: public; Owner: charlie
+-- Data for Name: accountdata; Type: TABLE DATA; Schema: public; Owner: -
 --
 
-INSERT INTO public.accountdata (accountid, dataname, datavalue, lastmodified) VALUES ('GCVIRZIN4CGYY56CSL7RYAFHKQTGE34GIASZ2D4IGZGV3FDL622LPQZT', 'dGVzdF9kYXRh', 'dGVzdF92YWx1ZQ==', 4);
+INSERT INTO public.accountdata VALUES ('GCVIRZIN4CGYY56CSL7RYAFHKQTGE34GIASZ2D4IGZGV3FDL622LPQZT', 'dGVzdF9kYXRh', 'dGVzdF92YWx1ZQ==', 4);
 
 
 --
--- Data for Name: accounts; Type: TABLE DATA; Schema: public; Owner: charlie
+-- Data for Name: accounts; Type: TABLE DATA; Schema: public; Owner: -
 --
 
-INSERT INTO public.accounts (accountid, balance, seqnum, numsubentries, inflationdest, homedomain, thresholds, flags, lastmodified, buyingliabilities, sellingliabilities) VALUES ('GBTVGCI5OYBGDMCNKYFVSETXK6TTOQ4DRJBAC5K2PUUNSVB24PPSQ26Q', 10000000000, 8589934592, 0, NULL, '', 'AQAAAA==', 0, 2, NULL, NULL);
-INSERT INTO public.accounts (accountid, balance, seqnum, numsubentries, inflationdest, homedomain, thresholds, flags, lastmodified, buyingliabilities, sellingliabilities) VALUES ('GBRPYHIL2CI3FNQ4BXLFMNDLFJUNPU2HY3ZMFSHONUCEOASW7QC7OX2H', 999999959999999600, 4, 0, NULL, '', 'AQAAAA==', 0, 2, NULL, NULL);
-INSERT INTO public.accounts (accountid, balance, seqnum, numsubentries, inflationdest, homedomain, thresholds, flags, lastmodified, buyingliabilities, sellingliabilities) VALUES ('GDQWLXN6B7IVBJ2Z2DB2VAEHYEJT4POZBB5DVPL2GWJ67YRSYPLTZ6WC', 9999999900, 8589934593, 1, NULL, '', 'AQAAAA==', 0, 3, NULL, NULL);
-INSERT INTO public.accounts (accountid, balance, seqnum, numsubentries, inflationdest, homedomain, thresholds, flags, lastmodified, buyingliabilities, sellingliabilities) VALUES ('GCY7C4WARB7NIABS3JRKK54A5NQSIVF4L5CIWIBPB6GKFOSESRLZVNMZ', 9999999900, 8589934593, 1, NULL, '', 'AQAAAA==', 0, 3, NULL, NULL);
-INSERT INTO public.accounts (accountid, balance, seqnum, numsubentries, inflationdest, homedomain, thresholds, flags, lastmodified, buyingliabilities, sellingliabilities) VALUES ('GCVIRZIN4CGYY56CSL7RYAFHKQTGE34GIASZ2D4IGZGV3FDL622LPQZT', 9999999900, 8589934593, 1, NULL, '', 'AQAAAA==', 0, 4, NULL, NULL);
+INSERT INTO public.accounts VALUES ('GBTVGCI5OYBGDMCNKYFVSETXK6TTOQ4DRJBAC5K2PUUNSVB24PPSQ26Q', 10000000000, 8589934592, 0, NULL, '', 'AQAAAA==', 0, 2, NULL, NULL);
+INSERT INTO public.accounts VALUES ('GBRPYHIL2CI3FNQ4BXLFMNDLFJUNPU2HY3ZMFSHONUCEOASW7QC7OX2H', 999999959999999600, 4, 0, NULL, '', 'AQAAAA==', 0, 2, NULL, NULL);
+INSERT INTO public.accounts VALUES ('GDQWLXN6B7IVBJ2Z2DB2VAEHYEJT4POZBB5DVPL2GWJ67YRSYPLTZ6WC', 9999999900, 8589934593, 1, NULL, '', 'AQAAAA==', 0, 3, NULL, NULL);
+INSERT INTO public.accounts VALUES ('GCY7C4WARB7NIABS3JRKK54A5NQSIVF4L5CIWIBPB6GKFOSESRLZVNMZ', 9999999900, 8589934593, 1, NULL, '', 'AQAAAA==', 0, 3, NULL, NULL);
+INSERT INTO public.accounts VALUES ('GCVIRZIN4CGYY56CSL7RYAFHKQTGE34GIASZ2D4IGZGV3FDL622LPQZT', 9999999900, 8589934593, 1, NULL, '', 'AQAAAA==', 0, 4, NULL, NULL);
 
 
 --
--- Data for Name: ban; Type: TABLE DATA; Schema: public; Owner: charlie
+-- Data for Name: ban; Type: TABLE DATA; Schema: public; Owner: -
 --
 
 
 
 --
--- Data for Name: ledgerheaders; Type: TABLE DATA; Schema: public; Owner: charlie
+-- Data for Name: ledgerheaders; Type: TABLE DATA; Schema: public; Owner: -
 --
 
-INSERT INTO public.ledgerheaders (ledgerhash, prevhash, bucketlisthash, ledgerseq, closetime, data) VALUES ('63d98f536ee68d1b27b5b89f23af5311b7569a24faf1403ad0b52b633b07be99', '0000000000000000000000000000000000000000000000000000000000000000', '572a2e32ff248a07b0e70fd1f6d318c1facd20b6cc08c33d5775259868125a16', 1, 0, 'AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABXKi4y/ySKB7DnD9H20xjB+s0gtswIwz1XdSWYaBJaFgAAAAEN4Lazp2QAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAZAX14QAAAABkAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA');
-INSERT INTO public.ledgerheaders (ledgerhash, prevhash, bucketlisthash, ledgerseq, closetime, data) VALUES ('564f13f11b354c55be8c84bd5520c745cd6472bb6a4ed224eba4646faf12a4f4', '63d98f536ee68d1b27b5b89f23af5311b7569a24faf1403ad0b52b633b07be99', '8646c7231c878bc770300c1ba5af4f52c43b6956453cb17d53450cc0b7b081c8', 2, 1538142762, 'AAAACmPZj1Nu5o0bJ7W4nyOvUxG3Vpok+vFAOtC1K2M7B76Z6ncT4HcPGyQz1f+yERxTOPhVOTC/nyiF0diQ/7xuz18AAAAAW64yKgAAAAIAAAAIAAAAAQAAAAoAAAAIAAAAAwAAJxAAAAAAc8/NjBwF+qQVB/2llzB2fBzuAqp9gXhlPmjFw7kwsN6GRscjHIeLx3AwDBulr09SxDtpVkU8sX1TRQzAt7CByAAAAAIN4Lazp2QAAAAAAAAAAAGQAAAAAAAAAAAAAAAAAAAAZAX14QAAACcQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA');
-INSERT INTO public.ledgerheaders (ledgerhash, prevhash, bucketlisthash, ledgerseq, closetime, data) VALUES ('d279d98759e1dc15a2d41270fc8002a4f425d113b8e63b6ce941e72788de3d97', '564f13f11b354c55be8c84bd5520c745cd6472bb6a4ed224eba4646faf12a4f4', 'e6c74e41149f7b83109389a52be53b99bde3eb7b8b7a847c1c62cd10fd8db4e1', 3, 1538142763, 'AAAAClZPE/EbNUxVvoyEvVUgx0XNZHK7ak7SJOukZG+vEqT0nirxrU8ET1zYDehB0P+znDoFJEAFAEZYF363l52nSz0AAAAAW64yKwAAAAAAAAAASRBtht4qOQAJcqaVqUpYJzsL77s/2Aw2gg7mDSqJYCXmx05BFJ97gxCTiaUr5TuZvePre4t6hHwcYs0Q/Y204QAAAAMN4Lazp2QAAAAAAAAAAAJYAAAAAAAAAAAAAAAAAAAAZAX14QAAACcQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA');
-INSERT INTO public.ledgerheaders (ledgerhash, prevhash, bucketlisthash, ledgerseq, closetime, data) VALUES ('d4ad6f562ffb0ccccee85a10f0da3c350ba3f300a23b1e13e54b4bdfae7ae61f', 'd279d98759e1dc15a2d41270fc8002a4f425d113b8e63b6ce941e72788de3d97', 'a60447c6ad9e2ce5e528d1c6703ce26b110e170fe9545018cab82d68030ccff1', 4, 1538142764, 'AAAACtJ52YdZ4dwVotQScPyAAqT0JdETuOY7bOlB5yeI3j2XbfmLFkML0bnopfyhJ7pKU+AHIbntLnXX4bUNjWKn2UEAAAAAW64yLAAAAAAAAAAAHWoMeWgpQkhAJsTZm4K7+1jl4NOUYyotQH+X0GAoDdGmBEfGrZ4s5eUo0cZwPOJrEQ4XD+lUUBjKuC1oAwzP8QAAAAQN4Lazp2QAAAAAAAAAAAK8AAAAAAAAAAAAAAAAAAAAZAX14QAAACcQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA');
-
-
---
--- Data for Name: offers; Type: TABLE DATA; Schema: public; Owner: charlie
---
-
+INSERT INTO public.ledgerheaders VALUES ('63d98f536ee68d1b27b5b89f23af5311b7569a24faf1403ad0b52b633b07be99', '0000000000000000000000000000000000000000000000000000000000000000', '572a2e32ff248a07b0e70fd1f6d318c1facd20b6cc08c33d5775259868125a16', 1, 0, 'AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABXKi4y/ySKB7DnD9H20xjB+s0gtswIwz1XdSWYaBJaFgAAAAEN4Lazp2QAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAZAX14QAAAABkAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA');
+INSERT INTO public.ledgerheaders VALUES ('564f13f11b354c55be8c84bd5520c745cd6472bb6a4ed224eba4646faf12a4f4', '63d98f536ee68d1b27b5b89f23af5311b7569a24faf1403ad0b52b633b07be99', '8646c7231c878bc770300c1ba5af4f52c43b6956453cb17d53450cc0b7b081c8', 2, 1538142762, 'AAAACmPZj1Nu5o0bJ7W4nyOvUxG3Vpok+vFAOtC1K2M7B76Z6ncT4HcPGyQz1f+yERxTOPhVOTC/nyiF0diQ/7xuz18AAAAAW64yKgAAAAIAAAAIAAAAAQAAAAoAAAAIAAAAAwAAJxAAAAAAc8/NjBwF+qQVB/2llzB2fBzuAqp9gXhlPmjFw7kwsN6GRscjHIeLx3AwDBulr09SxDtpVkU8sX1TRQzAt7CByAAAAAIN4Lazp2QAAAAAAAAAAAGQAAAAAAAAAAAAAAAAAAAAZAX14QAAACcQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA');
+INSERT INTO public.ledgerheaders VALUES ('d279d98759e1dc15a2d41270fc8002a4f425d113b8e63b6ce941e72788de3d97', '564f13f11b354c55be8c84bd5520c745cd6472bb6a4ed224eba4646faf12a4f4', 'e6c74e41149f7b83109389a52be53b99bde3eb7b8b7a847c1c62cd10fd8db4e1', 3, 1538142763, 'AAAAClZPE/EbNUxVvoyEvVUgx0XNZHK7ak7SJOukZG+vEqT0nirxrU8ET1zYDehB0P+znDoFJEAFAEZYF363l52nSz0AAAAAW64yKwAAAAAAAAAASRBtht4qOQAJcqaVqUpYJzsL77s/2Aw2gg7mDSqJYCXmx05BFJ97gxCTiaUr5TuZvePre4t6hHwcYs0Q/Y204QAAAAMN4Lazp2QAAAAAAAAAAAJYAAAAAAAAAAAAAAAAAAAAZAX14QAAACcQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA');
+INSERT INTO public.ledgerheaders VALUES ('d4ad6f562ffb0ccccee85a10f0da3c350ba3f300a23b1e13e54b4bdfae7ae61f', 'd279d98759e1dc15a2d41270fc8002a4f425d113b8e63b6ce941e72788de3d97', 'a60447c6ad9e2ce5e528d1c6703ce26b110e170fe9545018cab82d68030ccff1', 4, 1538142764, 'AAAACtJ52YdZ4dwVotQScPyAAqT0JdETuOY7bOlB5yeI3j2XbfmLFkML0bnopfyhJ7pKU+AHIbntLnXX4bUNjWKn2UEAAAAAW64yLAAAAAAAAAAAHWoMeWgpQkhAJsTZm4K7+1jl4NOUYyotQH+X0GAoDdGmBEfGrZ4s5eUo0cZwPOJrEQ4XD+lUUBjKuC1oAwzP8QAAAAQN4Lazp2QAAAAAAAAAAAK8AAAAAAAAAAAAAAAAAAAAZAX14QAAACcQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA');
 
 
 --
--- Data for Name: peers; Type: TABLE DATA; Schema: public; Owner: charlie
+-- Data for Name: offers; Type: TABLE DATA; Schema: public; Owner: -
 --
 
 
 
 --
--- Data for Name: publishqueue; Type: TABLE DATA; Schema: public; Owner: charlie
+-- Data for Name: peers; Type: TABLE DATA; Schema: public; Owner: -
 --
 
 
 
 --
--- Data for Name: pubsub; Type: TABLE DATA; Schema: public; Owner: charlie
+-- Data for Name: publishqueue; Type: TABLE DATA; Schema: public; Owner: -
 --
 
 
 
 --
--- Data for Name: scphistory; Type: TABLE DATA; Schema: public; Owner: charlie
+-- Data for Name: pubsub; Type: TABLE DATA; Schema: public; Owner: -
 --
 
-INSERT INTO public.scphistory (nodeid, ledgerseq, envelope) VALUES ('GDVV3C2TQKU7CYLLCES5EXJWQSMLJC33J3IKOBHZ6UWJ44ASOJ7OOIVH', 2, 'AAAAAOtdi1OCqfFhaxEl0l02hJi0i3tO0KcE+fUsnnAScn7nAAAAAAAAAAIAAAACAAAAAQAAAEjqdxPgdw8bJDPV/7IRHFM4+FU5ML+fKIXR2JD/vG7PXwAAAABbrjIqAAAAAgAAAAgAAAABAAAACgAAAAgAAAADAAAnEAAAAAAAAAABee12sYKMH2kWScdOhJ4hs74Dos7GHp7m4FMcW+5z4iIAAABADsR1ensZYiV8ncpG3rNGPAA/yPJYCoRR+3Ti8iT352VHKOnU9WvWJz7TwjsDtVwOX1PCbL9rQ1Z73+WiZMzwAQ==');
-INSERT INTO public.scphistory (nodeid, ledgerseq, envelope) VALUES ('GDVV3C2TQKU7CYLLCES5EXJWQSMLJC33J3IKOBHZ6UWJ44ASOJ7OOIVH', 3, 'AAAAAOtdi1OCqfFhaxEl0l02hJi0i3tO0KcE+fUsnnAScn7nAAAAAAAAAAMAAAACAAAAAQAAADCeKvGtTwRPXNgN6EHQ/7OcOgUkQAUARlgXfreXnadLPQAAAABbrjIrAAAAAAAAAAAAAAABee12sYKMH2kWScdOhJ4hs74Dos7GHp7m4FMcW+5z4iIAAABAgfKkyW4nEbbGP9uuUXXkcc4a3SFE+stxLgEOgS0LWUeNCTnFg5xd/SseHUdUaHhM/9S4T5r5OMPn8/d3cvZcDw==');
-INSERT INTO public.scphistory (nodeid, ledgerseq, envelope) VALUES ('GDVV3C2TQKU7CYLLCES5EXJWQSMLJC33J3IKOBHZ6UWJ44ASOJ7OOIVH', 4, 'AAAAAOtdi1OCqfFhaxEl0l02hJi0i3tO0KcE+fUsnnAScn7nAAAAAAAAAAQAAAACAAAAAQAAADBt+YsWQwvRueil/KEnukpT4Achue0uddfhtQ2NYqfZQQAAAABbrjIsAAAAAAAAAAAAAAABee12sYKMH2kWScdOhJ4hs74Dos7GHp7m4FMcW+5z4iIAAABA6w1cQstE5RsDGLD3j0LcARECk8cLqOnurVfTd8Htta5lxh9LR7oS+dLJSPnvqUgkaViJoep8IdxNZfvvwGJSCg==');
 
 
 --
--- Data for Name: scpquorums; Type: TABLE DATA; Schema: public; Owner: charlie
+-- Data for Name: scphistory; Type: TABLE DATA; Schema: public; Owner: -
 --
 
-INSERT INTO public.scpquorums (qsethash, lastledgerseq, qset) VALUES ('79ed76b1828c1f691649c74e849e21b3be03a2cec61e9ee6e0531c5bee73e222', 4, 'AAAAAQAAAAEAAAAA612LU4Kp8WFrESXSXTaEmLSLe07QpwT59SyecBJyfucAAAAA');
-
-
---
--- Data for Name: signers; Type: TABLE DATA; Schema: public; Owner: charlie
---
-
-INSERT INTO public.signers (accountid, publickey, weight) VALUES ('GDQWLXN6B7IVBJ2Z2DB2VAEHYEJT4POZBB5DVPL2GWJ67YRSYPLTZ6WC', 'GCVIRZIN4CGYY56CSL7RYAFHKQTGE34GIASZ2D4IGZGV3FDL622LPQZT', 1);
+INSERT INTO public.scphistory VALUES ('GDVV3C2TQKU7CYLLCES5EXJWQSMLJC33J3IKOBHZ6UWJ44ASOJ7OOIVH', 2, 'AAAAAOtdi1OCqfFhaxEl0l02hJi0i3tO0KcE+fUsnnAScn7nAAAAAAAAAAIAAAACAAAAAQAAAEjqdxPgdw8bJDPV/7IRHFM4+FU5ML+fKIXR2JD/vG7PXwAAAABbrjIqAAAAAgAAAAgAAAABAAAACgAAAAgAAAADAAAnEAAAAAAAAAABee12sYKMH2kWScdOhJ4hs74Dos7GHp7m4FMcW+5z4iIAAABADsR1ensZYiV8ncpG3rNGPAA/yPJYCoRR+3Ti8iT352VHKOnU9WvWJz7TwjsDtVwOX1PCbL9rQ1Z73+WiZMzwAQ==');
+INSERT INTO public.scphistory VALUES ('GDVV3C2TQKU7CYLLCES5EXJWQSMLJC33J3IKOBHZ6UWJ44ASOJ7OOIVH', 3, 'AAAAAOtdi1OCqfFhaxEl0l02hJi0i3tO0KcE+fUsnnAScn7nAAAAAAAAAAMAAAACAAAAAQAAADCeKvGtTwRPXNgN6EHQ/7OcOgUkQAUARlgXfreXnadLPQAAAABbrjIrAAAAAAAAAAAAAAABee12sYKMH2kWScdOhJ4hs74Dos7GHp7m4FMcW+5z4iIAAABAgfKkyW4nEbbGP9uuUXXkcc4a3SFE+stxLgEOgS0LWUeNCTnFg5xd/SseHUdUaHhM/9S4T5r5OMPn8/d3cvZcDw==');
+INSERT INTO public.scphistory VALUES ('GDVV3C2TQKU7CYLLCES5EXJWQSMLJC33J3IKOBHZ6UWJ44ASOJ7OOIVH', 4, 'AAAAAOtdi1OCqfFhaxEl0l02hJi0i3tO0KcE+fUsnnAScn7nAAAAAAAAAAQAAAACAAAAAQAAADBt+YsWQwvRueil/KEnukpT4Achue0uddfhtQ2NYqfZQQAAAABbrjIsAAAAAAAAAAAAAAABee12sYKMH2kWScdOhJ4hs74Dos7GHp7m4FMcW+5z4iIAAABA6w1cQstE5RsDGLD3j0LcARECk8cLqOnurVfTd8Htta5lxh9LR7oS+dLJSPnvqUgkaViJoep8IdxNZfvvwGJSCg==');
 
 
 --
--- Data for Name: storestate; Type: TABLE DATA; Schema: public; Owner: charlie
+-- Data for Name: scpquorums; Type: TABLE DATA; Schema: public; Owner: -
 --
 
-INSERT INTO public.storestate (statename, state) VALUES ('lastclosedledger                ', 'd4ad6f562ffb0ccccee85a10f0da3c350ba3f300a23b1e13e54b4bdfae7ae61f');
-INSERT INTO public.storestate (statename, state) VALUES ('historyarchivestate             ', '{
+INSERT INTO public.scpquorums VALUES ('79ed76b1828c1f691649c74e849e21b3be03a2cec61e9ee6e0531c5bee73e222', 4, 'AAAAAQAAAAEAAAAA612LU4Kp8WFrESXSXTaEmLSLe07QpwT59SyecBJyfucAAAAA');
+
+
+--
+-- Data for Name: signers; Type: TABLE DATA; Schema: public; Owner: -
+--
+
+INSERT INTO public.signers VALUES ('GDQWLXN6B7IVBJ2Z2DB2VAEHYEJT4POZBB5DVPL2GWJ67YRSYPLTZ6WC', 'GCVIRZIN4CGYY56CSL7RYAFHKQTGE34GIASZ2D4IGZGV3FDL622LPQZT', 1);
+
+
+--
+-- Data for Name: storestate; Type: TABLE DATA; Schema: public; Owner: -
+--
+
+INSERT INTO public.storestate VALUES ('lastclosedledger                ', 'd4ad6f562ffb0ccccee85a10f0da3c350ba3f300a23b1e13e54b4bdfae7ae61f');
+INSERT INTO public.storestate VALUES ('historyarchivestate             ', '{
     "version": 1,
     "server": "v10.0.0",
     "currentLedger": 4,
@@ -555,11 +491,11 @@ INSERT INTO public.storestate (statename, state) VALUES ('historyarchivestate   
         }
     ]
 }');
-INSERT INTO public.storestate (statename, state) VALUES ('lastscpdata                     ', 'AAAAAgAAAADrXYtTgqnxYWsRJdJdNoSYtIt7TtCnBPn1LJ5wEnJ+5wAAAAAAAAAEAAAAA3ntdrGCjB9pFknHToSeIbO+A6LOxh6e5uBTHFvuc+IiAAAAAQAAADBt+YsWQwvRueil/KEnukpT4Achue0uddfhtQ2NYqfZQQAAAABbrjIsAAAAAAAAAAAAAAABAAAAMG35ixZDC9G56KX8oSe6SlPgByG57S511+G1DY1ip9lBAAAAAFuuMiwAAAAAAAAAAAAAAEB2DBi/Viehmy1h9GcEThlXiGo4GG19klTmUFxWhFKQh33HNaC/9hvAOJ4O8Pt6HXSnVuXRy9rA6Ss1mu+58c8BAAAAAOtdi1OCqfFhaxEl0l02hJi0i3tO0KcE+fUsnnAScn7nAAAAAAAAAAQAAAACAAAAAQAAADBt+YsWQwvRueil/KEnukpT4Achue0uddfhtQ2NYqfZQQAAAABbrjIsAAAAAAAAAAAAAAABee12sYKMH2kWScdOhJ4hs74Dos7GHp7m4FMcW+5z4iIAAABA6w1cQstE5RsDGLD3j0LcARECk8cLqOnurVfTd8Htta5lxh9LR7oS+dLJSPnvqUgkaViJoep8IdxNZfvvwGJSCgAAAAHSedmHWeHcFaLUEnD8gAKk9CXRE7jmO2zpQecniN49lwAAAAEAAAAAqojlDeCNjHfCkv8cAKdUJmJvhkAlnQ+INk1dlGv2tLcAAABkAAAAAgAAAAEAAAAAAAAAAAAAAAEAAAAAAAAACgAAAAl0ZXN0X2RhdGEAAAAAAAABAAAACnRlc3RfdmFsdWUAAAAAAAAAAAABa/a0twAAAEDIECPO8kfwRphAjTs+Mpck3akbBzAjoc09tPX7vp6FsT+pV7Kc/PPJIXnRA3CYEmvySJl1nOtaav8SNfuKq6sMAAAAAQAAAAEAAAABAAAAAOtdi1OCqfFhaxEl0l02hJi0i3tO0KcE+fUsnnAScn7nAAAAAA==');
-INSERT INTO public.storestate (statename, state) VALUES ('databaseschema                  ', '7');
-INSERT INTO public.storestate (statename, state) VALUES ('networkpassphrase               ', 'Test SDF Network ; September 2015');
-INSERT INTO public.storestate (statename, state) VALUES ('forcescponnextlaunch            ', 'false');
-INSERT INTO public.storestate (statename, state) VALUES ('ledgerupgrades                  ', '{
+INSERT INTO public.storestate VALUES ('lastscpdata                     ', 'AAAAAgAAAADrXYtTgqnxYWsRJdJdNoSYtIt7TtCnBPn1LJ5wEnJ+5wAAAAAAAAAEAAAAA3ntdrGCjB9pFknHToSeIbO+A6LOxh6e5uBTHFvuc+IiAAAAAQAAADBt+YsWQwvRueil/KEnukpT4Achue0uddfhtQ2NYqfZQQAAAABbrjIsAAAAAAAAAAAAAAABAAAAMG35ixZDC9G56KX8oSe6SlPgByG57S511+G1DY1ip9lBAAAAAFuuMiwAAAAAAAAAAAAAAEB2DBi/Viehmy1h9GcEThlXiGo4GG19klTmUFxWhFKQh33HNaC/9hvAOJ4O8Pt6HXSnVuXRy9rA6Ss1mu+58c8BAAAAAOtdi1OCqfFhaxEl0l02hJi0i3tO0KcE+fUsnnAScn7nAAAAAAAAAAQAAAACAAAAAQAAADBt+YsWQwvRueil/KEnukpT4Achue0uddfhtQ2NYqfZQQAAAABbrjIsAAAAAAAAAAAAAAABee12sYKMH2kWScdOhJ4hs74Dos7GHp7m4FMcW+5z4iIAAABA6w1cQstE5RsDGLD3j0LcARECk8cLqOnurVfTd8Htta5lxh9LR7oS+dLJSPnvqUgkaViJoep8IdxNZfvvwGJSCgAAAAHSedmHWeHcFaLUEnD8gAKk9CXRE7jmO2zpQecniN49lwAAAAEAAAAAqojlDeCNjHfCkv8cAKdUJmJvhkAlnQ+INk1dlGv2tLcAAABkAAAAAgAAAAEAAAAAAAAAAAAAAAEAAAAAAAAACgAAAAl0ZXN0X2RhdGEAAAAAAAABAAAACnRlc3RfdmFsdWUAAAAAAAAAAAABa/a0twAAAEDIECPO8kfwRphAjTs+Mpck3akbBzAjoc09tPX7vp6FsT+pV7Kc/PPJIXnRA3CYEmvySJl1nOtaav8SNfuKq6sMAAAAAQAAAAEAAAABAAAAAOtdi1OCqfFhaxEl0l02hJi0i3tO0KcE+fUsnnAScn7nAAAAAA==');
+INSERT INTO public.storestate VALUES ('databaseschema                  ', '7');
+INSERT INTO public.storestate VALUES ('networkpassphrase               ', 'Test SDF Network ; September 2015');
+INSERT INTO public.storestate VALUES ('forcescponnextlaunch            ', 'false');
+INSERT INTO public.storestate VALUES ('ledgerupgrades                  ', '{
     "time": 0,
     "version": {
         "has": false
@@ -577,48 +513,70 @@ INSERT INTO public.storestate (statename, state) VALUES ('ledgerupgrades        
 
 
 --
--- Data for Name: trustlines; Type: TABLE DATA; Schema: public; Owner: charlie
+-- Data for Name: trustlines; Type: TABLE DATA; Schema: public; Owner: -
 --
 
-INSERT INTO public.trustlines (accountid, assettype, issuer, assetcode, tlimit, balance, flags, lastmodified, buyingliabilities, sellingliabilities) VALUES ('GCY7C4WARB7NIABS3JRKK54A5NQSIVF4L5CIWIBPB6GKFOSESRLZVNMZ', 1, 'GBTVGCI5OYBGDMCNKYFVSETXK6TTOQ4DRJBAC5K2PUUNSVB24PPSQ26Q', 'KHL', 9223372036854775807, 0, 1, 3, NULL, NULL);
-
-
---
--- Data for Name: txfeehistory; Type: TABLE DATA; Schema: public; Owner: charlie
---
-
-INSERT INTO public.txfeehistory (txid, ledgerseq, txindex, txchanges) VALUES ('c3bc990f06136ed43088920f58ae2ae034b3075992637d2eeb0a9d351d4eba91', 2, 1, 'AAAAAgAAAAMAAAABAAAAAAAAAABi/B0L0JGythwN1lY0aypo19NHxvLCyO5tBEcCVvwF9w3gtrOnZAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAEAAAACAAAAAAAAAABi/B0L0JGythwN1lY0aypo19NHxvLCyO5tBEcCVvwF9w3gtrOnY/+cAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAA==');
-INSERT INTO public.txfeehistory (txid, ledgerseq, txindex, txchanges) VALUES ('647646ee4cb26f006f58546fdf0423ebe44fcecd277c12f4983c1e180af1d390', 2, 2, 'AAAAAgAAAAMAAAACAAAAAAAAAABi/B0L0JGythwN1lY0aypo19NHxvLCyO5tBEcCVvwF9w3gtrOnY/+cAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAEAAAACAAAAAAAAAABi/B0L0JGythwN1lY0aypo19NHxvLCyO5tBEcCVvwF9w3gtrOnY/84AAAAAAAAAAIAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAA==');
-INSERT INTO public.txfeehistory (txid, ledgerseq, txindex, txchanges) VALUES ('d714bde56f5d745a06770fbd31eb9751a9988f5be625cfebfeef578767d6bd89', 2, 3, 'AAAAAgAAAAMAAAACAAAAAAAAAABi/B0L0JGythwN1lY0aypo19NHxvLCyO5tBEcCVvwF9w3gtrOnY/84AAAAAAAAAAIAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAEAAAACAAAAAAAAAABi/B0L0JGythwN1lY0aypo19NHxvLCyO5tBEcCVvwF9w3gtrOnY/7UAAAAAAAAAAMAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAA==');
-INSERT INTO public.txfeehistory (txid, ledgerseq, txindex, txchanges) VALUES ('df29b2cead92334dbd7d778ac90e27dfe281cdd979b3a24e228d62e30efafa01', 2, 4, 'AAAAAgAAAAMAAAACAAAAAAAAAABi/B0L0JGythwN1lY0aypo19NHxvLCyO5tBEcCVvwF9w3gtrOnY/7UAAAAAAAAAAMAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAEAAAACAAAAAAAAAABi/B0L0JGythwN1lY0aypo19NHxvLCyO5tBEcCVvwF9w3gtrOnY/5wAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAA==');
-INSERT INTO public.txfeehistory (txid, ledgerseq, txindex, txchanges) VALUES ('6bbe6b17bb71d7429dc9476fd77c5f9a18b915fd11f2c8b54e9029ae6554f6ef', 3, 1, 'AAAAAgAAAAMAAAACAAAAAAAAAADhZd2+D9FQp1nQw6qAh8ETPj3ZCHo6vXo1k+/iMsPXPAAAAAJUC+QAAAAAAgAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAEAAAADAAAAAAAAAADhZd2+D9FQp1nQw6qAh8ETPj3ZCHo6vXo1k+/iMsPXPAAAAAJUC+OcAAAAAgAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAA==');
-INSERT INTO public.txfeehistory (txid, ledgerseq, txindex, txchanges) VALUES ('88b573ac5441c3934ae6d849c93429bcaa8d83823581b7d72227c8cf06389dd7', 3, 2, 'AAAAAgAAAAMAAAACAAAAAAAAAACx8XLAiH7UADLaYqV3gOthJFS8X0SLIC8PjKK6RJRXmgAAAAJUC+QAAAAAAgAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAEAAAADAAAAAAAAAACx8XLAiH7UADLaYqV3gOthJFS8X0SLIC8PjKK6RJRXmgAAAAJUC+OcAAAAAgAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAA==');
-INSERT INTO public.txfeehistory (txid, ledgerseq, txindex, txchanges) VALUES ('b5f4d71a8ef136431f9495c3747c70a97a9dc4f33322ed7bd09174975d150ccf', 4, 1, 'AAAAAgAAAAMAAAACAAAAAAAAAACqiOUN4I2Md8KS/xwAp1QmYm+GQCWdD4g2TV2Ua/a0twAAAAJUC+QAAAAAAgAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAEAAAAEAAAAAAAAAACqiOUN4I2Md8KS/xwAp1QmYm+GQCWdD4g2TV2Ua/a0twAAAAJUC+OcAAAAAgAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAA==');
+INSERT INTO public.trustlines VALUES ('GCY7C4WARB7NIABS3JRKK54A5NQSIVF4L5CIWIBPB6GKFOSESRLZVNMZ', 1, 'GBTVGCI5OYBGDMCNKYFVSETXK6TTOQ4DRJBAC5K2PUUNSVB24PPSQ26Q', 'KHL', 9223372036854775807, 0, 1, 3, NULL, NULL);
 
 
 --
--- Data for Name: txhistory; Type: TABLE DATA; Schema: public; Owner: charlie
+-- Data for Name: txfeehistory; Type: TABLE DATA; Schema: public; Owner: -
 --
 
-INSERT INTO public.txhistory (txid, ledgerseq, txindex, txbody, txresult, txmeta) VALUES ('c3bc990f06136ed43088920f58ae2ae034b3075992637d2eeb0a9d351d4eba91', 2, 1, 'AAAAAGL8HQvQkbK2HA3WVjRrKmjX00fG8sLI7m0ERwJW/AX3AAAAZAAAAAAAAAABAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAZ1MJHXYCYbBNVgtZEndXpzdDg4pCAXVafSjZVDrj3ygAAAACVAvkAAAAAAAAAAABVvwF9wAAAECtxau60cUj7Xmb5/v7/RJe/SgqWkTSt1qH9hLERe2YcepDcF2FD97zxUpZ6bDbDdLMMrvboV5Gh+k8C29EOtoI', 'w7yZDwYTbtQwiJIPWK4q4DSzB1mSY30u6wqdNR1OupEAAAAAAAAAZAAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAA==', 'AAAAAQAAAAAAAAABAAAAAgAAAAAAAAACAAAAAAAAAABnUwkddgJhsE1WC1kSd1enN0ODikIBdVp9KNlUOuPfKAAAAAJUC+QAAAAAAgAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAEAAAACAAAAAAAAAABi/B0L0JGythwN1lY0aypo19NHxvLCyO5tBEcCVvwF9w3gtrFTWBpwAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAA==');
-INSERT INTO public.txhistory (txid, ledgerseq, txindex, txbody, txresult, txmeta) VALUES ('647646ee4cb26f006f58546fdf0423ebe44fcecd277c12f4983c1e180af1d390', 2, 2, 'AAAAAGL8HQvQkbK2HA3WVjRrKmjX00fG8sLI7m0ERwJW/AX3AAAAZAAAAAAAAAACAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAA4WXdvg/RUKdZ0MOqgIfBEz492Qh6Or16NZPv4jLD1zwAAAACVAvkAAAAAAAAAAABVvwF9wAAAEBPmU8p7LrGpKUCz4qQmbxOYYwkfYyKe8ZKtRw6F5hNvD6YpGQAkPEsiCI8N4JrpKnkkHD3cIsYeWexHhCtoiMI', 'ZHZG7kyybwBvWFRv3wQj6+RPzs0nfBL0mDweGArx05AAAAAAAAAAZAAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAA==', 'AAAAAQAAAAAAAAABAAAAAgAAAAAAAAACAAAAAAAAAADhZd2+D9FQp1nQw6qAh8ETPj3ZCHo6vXo1k+/iMsPXPAAAAAJUC+QAAAAAAgAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAEAAAACAAAAAAAAAABi/B0L0JGythwN1lY0aypo19NHxvLCyO5tBEcCVvwF9w3gtq7/TDZwAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAA==');
-INSERT INTO public.txhistory (txid, ledgerseq, txindex, txbody, txresult, txmeta) VALUES ('d714bde56f5d745a06770fbd31eb9751a9988f5be625cfebfeef578767d6bd89', 2, 3, 'AAAAAGL8HQvQkbK2HA3WVjRrKmjX00fG8sLI7m0ERwJW/AX3AAAAZAAAAAAAAAADAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAqojlDeCNjHfCkv8cAKdUJmJvhkAlnQ+INk1dlGv2tLcAAAACVAvkAAAAAAAAAAABVvwF9wAAAEBAc9IDiA8bdVg97qNJIb8Yx9njHJOfouobKw1unDu40/rULoP64v1felhxDEUwSdYvHpdaoIUWIKZA9eQrdBEF', '1xS95W9ddFoGdw+9MeuXUamYj1vmJc/r/u9Xh2fWvYkAAAAAAAAAZAAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAA==', 'AAAAAQAAAAAAAAABAAAAAgAAAAAAAAACAAAAAAAAAACqiOUN4I2Md8KS/xwAp1QmYm+GQCWdD4g2TV2Ua/a0twAAAAJUC+QAAAAAAgAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAEAAAACAAAAAAAAAABi/B0L0JGythwN1lY0aypo19NHxvLCyO5tBEcCVvwF9w3gtqyrQFJwAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAA==');
-INSERT INTO public.txhistory (txid, ledgerseq, txindex, txbody, txresult, txmeta) VALUES ('df29b2cead92334dbd7d778ac90e27dfe281cdd979b3a24e228d62e30efafa01', 2, 4, 'AAAAAGL8HQvQkbK2HA3WVjRrKmjX00fG8sLI7m0ERwJW/AX3AAAAZAAAAAAAAAAEAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAsfFywIh+1AAy2mKld4DrYSRUvF9EiyAvD4yiukSUV5oAAAACVAvkAAAAAAAAAAABVvwF9wAAAEDaB9j+85KWEwq2Kcm27EII9PxWWEwQa1Yh9gtxy7OwncgzEwihyqfVStaODWBy+JEjZ6ySL2GbHeLeKkJx44sI', '3ymyzq2SM029fXeKyQ4n3+KBzdl5s6JOIo1i4w76+gEAAAAAAAAAZAAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAA==', 'AAAAAQAAAAAAAAABAAAAAgAAAAAAAAACAAAAAAAAAACx8XLAiH7UADLaYqV3gOthJFS8X0SLIC8PjKK6RJRXmgAAAAJUC+QAAAAAAgAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAEAAAACAAAAAAAAAABi/B0L0JGythwN1lY0aypo19NHxvLCyO5tBEcCVvwF9w3gtqpXNG5wAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAA==');
-INSERT INTO public.txhistory (txid, ledgerseq, txindex, txbody, txresult, txmeta) VALUES ('6bbe6b17bb71d7429dc9476fd77c5f9a18b915fd11f2c8b54e9029ae6554f6ef', 3, 1, 'AAAAAOFl3b4P0VCnWdDDqoCHwRM+PdkIejq9ejWT7+Iyw9c8AAAAZAAAAAIAAAABAAAAAAAAAAAAAAABAAAAAAAAAAUAAAAAAAAAAQAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAACqiOUN4I2Md8KS/xwAp1QmYm+GQCWdD4g2TV2Ua/a0twAAAAEAAAAAAAAAATLD1zwAAABATfVpGYYrQJilxLxmEJbz/XeOhzLM1jox/4U6o6R7HUWtwmrtMAHpj3lmFJnF+jRfl74AV3fA1Mo8OU1dVJhaDA==', 'a75rF7tx10KdyUdv13xfmhi5Ff0R8si1TpAprmVU9u8AAAAAAAAAZAAAAAAAAAABAAAAAAAAAAUAAAAAAAAAAA==', 'AAAAAQAAAAIAAAADAAAAAwAAAAAAAAAA4WXdvg/RUKdZ0MOqgIfBEz492Qh6Or16NZPv4jLD1zwAAAACVAvjnAAAAAIAAAAAAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAAABAAAAAwAAAAAAAAAA4WXdvg/RUKdZ0MOqgIfBEz492Qh6Or16NZPv4jLD1zwAAAACVAvjnAAAAAIAAAABAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAAABAAAAAgAAAAMAAAADAAAAAAAAAADhZd2+D9FQp1nQw6qAh8ETPj3ZCHo6vXo1k+/iMsPXPAAAAAJUC+OcAAAAAgAAAAEAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAEAAAADAAAAAAAAAADhZd2+D9FQp1nQw6qAh8ETPj3ZCHo6vXo1k+/iMsPXPAAAAAJUC+OcAAAAAgAAAAEAAAABAAAAAAAAAAAAAAAAAQAAAAAAAAEAAAAAqojlDeCNjHfCkv8cAKdUJmJvhkAlnQ+INk1dlGv2tLcAAAABAAAAAAAAAAA=');
-INSERT INTO public.txhistory (txid, ledgerseq, txindex, txbody, txresult, txmeta) VALUES ('88b573ac5441c3934ae6d849c93429bcaa8d83823581b7d72227c8cf06389dd7', 3, 2, 'AAAAALHxcsCIftQAMtpipXeA62EkVLxfRIsgLw+MorpElFeaAAAAZAAAAAIAAAABAAAAAAAAAAAAAAABAAAAAAAAAAYAAAABS0hMAAAAAABnUwkddgJhsE1WC1kSd1enN0ODikIBdVp9KNlUOuPfKH//////////AAAAAAAAAAFElFeaAAAAQF5t+G+v86jAxeXKuSMO5o/A5+qMFT5dPN60bDohBzBFRDV7j3fbt9buXnAkEVAnMVRCDj7VZGRTBlGPpenErgs=', 'iLVzrFRBw5NK5thJyTQpvKqNg4I1gbfXIifIzwY4ndcAAAAAAAAAZAAAAAAAAAABAAAAAAAAAAYAAAAAAAAAAA==', 'AAAAAQAAAAIAAAADAAAAAwAAAAAAAAAAsfFywIh+1AAy2mKld4DrYSRUvF9EiyAvD4yiukSUV5oAAAACVAvjnAAAAAIAAAAAAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAAABAAAAAwAAAAAAAAAAsfFywIh+1AAy2mKld4DrYSRUvF9EiyAvD4yiukSUV5oAAAACVAvjnAAAAAIAAAABAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAAABAAAAAwAAAAAAAAADAAAAAQAAAACx8XLAiH7UADLaYqV3gOthJFS8X0SLIC8PjKK6RJRXmgAAAAFLSEwAAAAAAGdTCR12AmGwTVYLWRJ3V6c3Q4OKQgF1Wn0o2VQ6498oAAAAAAAAAAB//////////wAAAAEAAAAAAAAAAAAAAAMAAAADAAAAAAAAAACx8XLAiH7UADLaYqV3gOthJFS8X0SLIC8PjKK6RJRXmgAAAAJUC+OcAAAAAgAAAAEAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAEAAAADAAAAAAAAAACx8XLAiH7UADLaYqV3gOthJFS8X0SLIC8PjKK6RJRXmgAAAAJUC+OcAAAAAgAAAAEAAAABAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAA==');
-INSERT INTO public.txhistory (txid, ledgerseq, txindex, txbody, txresult, txmeta) VALUES ('b5f4d71a8ef136431f9495c3747c70a97a9dc4f33322ed7bd09174975d150ccf', 4, 1, 'AAAAAKqI5Q3gjYx3wpL/HACnVCZib4ZAJZ0PiDZNXZRr9rS3AAAAZAAAAAIAAAABAAAAAAAAAAAAAAABAAAAAAAAAAoAAAAJdGVzdF9kYXRhAAAAAAAAAQAAAAp0ZXN0X3ZhbHVlAAAAAAAAAAAAAWv2tLcAAABAyBAjzvJH8EaYQI07PjKXJN2pGwcwI6HNPbT1+76ehbE/qVeynPzzySF50QNwmBJr8kiZdZzrWmr/EjX7iqurDA==', 'tfTXGo7xNkMflJXDdHxwqXqdxPMzIu170JF0l10VDM8AAAAAAAAAZAAAAAAAAAABAAAAAAAAAAoAAAAAAAAAAA==', 'AAAAAQAAAAIAAAADAAAABAAAAAAAAAAAqojlDeCNjHfCkv8cAKdUJmJvhkAlnQ+INk1dlGv2tLcAAAACVAvjnAAAAAIAAAAAAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAAABAAAABAAAAAAAAAAAqojlDeCNjHfCkv8cAKdUJmJvhkAlnQ+INk1dlGv2tLcAAAACVAvjnAAAAAIAAAABAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAAABAAAAAwAAAAAAAAAEAAAAAwAAAACqiOUN4I2Md8KS/xwAp1QmYm+GQCWdD4g2TV2Ua/a0twAAAAl0ZXN0X2RhdGEAAAAAAAAKdGVzdF92YWx1ZQAAAAAAAAAAAAAAAAADAAAABAAAAAAAAAAAqojlDeCNjHfCkv8cAKdUJmJvhkAlnQ+INk1dlGv2tLcAAAACVAvjnAAAAAIAAAABAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAAABAAAABAAAAAAAAAAAqojlDeCNjHfCkv8cAKdUJmJvhkAlnQ+INk1dlGv2tLcAAAACVAvjnAAAAAIAAAABAAAAAQAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAA=');
-
-
---
--- Data for Name: upgradehistory; Type: TABLE DATA; Schema: public; Owner: charlie
---
-
-INSERT INTO public.upgradehistory (ledgerseq, upgradeindex, upgrade, changes) VALUES (2, 1, 'AAAAAQAAAAo=', 'AAAAAA==');
-INSERT INTO public.upgradehistory (ledgerseq, upgradeindex, upgrade, changes) VALUES (2, 2, 'AAAAAwAAJxA=', 'AAAAAA==');
+INSERT INTO public.txfeehistory VALUES ('c3bc990f06136ed43088920f58ae2ae034b3075992637d2eeb0a9d351d4eba91', 2, 1, 'AAAAAgAAAAMAAAABAAAAAAAAAABi/B0L0JGythwN1lY0aypo19NHxvLCyO5tBEcCVvwF9w3gtrOnZAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAEAAAACAAAAAAAAAABi/B0L0JGythwN1lY0aypo19NHxvLCyO5tBEcCVvwF9w3gtrOnY/+cAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAA==');
+INSERT INTO public.txfeehistory VALUES ('647646ee4cb26f006f58546fdf0423ebe44fcecd277c12f4983c1e180af1d390', 2, 2, 'AAAAAgAAAAMAAAACAAAAAAAAAABi/B0L0JGythwN1lY0aypo19NHxvLCyO5tBEcCVvwF9w3gtrOnY/+cAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAEAAAACAAAAAAAAAABi/B0L0JGythwN1lY0aypo19NHxvLCyO5tBEcCVvwF9w3gtrOnY/84AAAAAAAAAAIAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAA==');
+INSERT INTO public.txfeehistory VALUES ('d714bde56f5d745a06770fbd31eb9751a9988f5be625cfebfeef578767d6bd89', 2, 3, 'AAAAAgAAAAMAAAACAAAAAAAAAABi/B0L0JGythwN1lY0aypo19NHxvLCyO5tBEcCVvwF9w3gtrOnY/84AAAAAAAAAAIAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAEAAAACAAAAAAAAAABi/B0L0JGythwN1lY0aypo19NHxvLCyO5tBEcCVvwF9w3gtrOnY/7UAAAAAAAAAAMAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAA==');
+INSERT INTO public.txfeehistory VALUES ('df29b2cead92334dbd7d778ac90e27dfe281cdd979b3a24e228d62e30efafa01', 2, 4, 'AAAAAgAAAAMAAAACAAAAAAAAAABi/B0L0JGythwN1lY0aypo19NHxvLCyO5tBEcCVvwF9w3gtrOnY/7UAAAAAAAAAAMAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAEAAAACAAAAAAAAAABi/B0L0JGythwN1lY0aypo19NHxvLCyO5tBEcCVvwF9w3gtrOnY/5wAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAA==');
+INSERT INTO public.txfeehistory VALUES ('6bbe6b17bb71d7429dc9476fd77c5f9a18b915fd11f2c8b54e9029ae6554f6ef', 3, 1, 'AAAAAgAAAAMAAAACAAAAAAAAAADhZd2+D9FQp1nQw6qAh8ETPj3ZCHo6vXo1k+/iMsPXPAAAAAJUC+QAAAAAAgAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAEAAAADAAAAAAAAAADhZd2+D9FQp1nQw6qAh8ETPj3ZCHo6vXo1k+/iMsPXPAAAAAJUC+OcAAAAAgAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAA==');
+INSERT INTO public.txfeehistory VALUES ('88b573ac5441c3934ae6d849c93429bcaa8d83823581b7d72227c8cf06389dd7', 3, 2, 'AAAAAgAAAAMAAAACAAAAAAAAAACx8XLAiH7UADLaYqV3gOthJFS8X0SLIC8PjKK6RJRXmgAAAAJUC+QAAAAAAgAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAEAAAADAAAAAAAAAACx8XLAiH7UADLaYqV3gOthJFS8X0SLIC8PjKK6RJRXmgAAAAJUC+OcAAAAAgAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAA==');
+INSERT INTO public.txfeehistory VALUES ('b5f4d71a8ef136431f9495c3747c70a97a9dc4f33322ed7bd09174975d150ccf', 4, 1, 'AAAAAgAAAAMAAAACAAAAAAAAAACqiOUN4I2Md8KS/xwAp1QmYm+GQCWdD4g2TV2Ua/a0twAAAAJUC+QAAAAAAgAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAEAAAAEAAAAAAAAAACqiOUN4I2Md8KS/xwAp1QmYm+GQCWdD4g2TV2Ua/a0twAAAAJUC+OcAAAAAgAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAA==');
 
 
 --
--- Name: accountdata accountdata_pkey; Type: CONSTRAINT; Schema: public; Owner: charlie
+-- Data for Name: txhistory; Type: TABLE DATA; Schema: public; Owner: -
+--
+
+INSERT INTO public.txhistory VALUES ('c3bc990f06136ed43088920f58ae2ae034b3075992637d2eeb0a9d351d4eba91', 2, 1, 'AAAAAGL8HQvQkbK2HA3WVjRrKmjX00fG8sLI7m0ERwJW/AX3AAAAZAAAAAAAAAABAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAZ1MJHXYCYbBNVgtZEndXpzdDg4pCAXVafSjZVDrj3ygAAAACVAvkAAAAAAAAAAABVvwF9wAAAECtxau60cUj7Xmb5/v7/RJe/SgqWkTSt1qH9hLERe2YcepDcF2FD97zxUpZ6bDbDdLMMrvboV5Gh+k8C29EOtoI', 'w7yZDwYTbtQwiJIPWK4q4DSzB1mSY30u6wqdNR1OupEAAAAAAAAAZAAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAA==', 'AAAAAQAAAAAAAAABAAAAAgAAAAAAAAACAAAAAAAAAABnUwkddgJhsE1WC1kSd1enN0ODikIBdVp9KNlUOuPfKAAAAAJUC+QAAAAAAgAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAEAAAACAAAAAAAAAABi/B0L0JGythwN1lY0aypo19NHxvLCyO5tBEcCVvwF9w3gtrFTWBpwAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAA==');
+INSERT INTO public.txhistory VALUES ('647646ee4cb26f006f58546fdf0423ebe44fcecd277c12f4983c1e180af1d390', 2, 2, 'AAAAAGL8HQvQkbK2HA3WVjRrKmjX00fG8sLI7m0ERwJW/AX3AAAAZAAAAAAAAAACAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAA4WXdvg/RUKdZ0MOqgIfBEz492Qh6Or16NZPv4jLD1zwAAAACVAvkAAAAAAAAAAABVvwF9wAAAEBPmU8p7LrGpKUCz4qQmbxOYYwkfYyKe8ZKtRw6F5hNvD6YpGQAkPEsiCI8N4JrpKnkkHD3cIsYeWexHhCtoiMI', 'ZHZG7kyybwBvWFRv3wQj6+RPzs0nfBL0mDweGArx05AAAAAAAAAAZAAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAA==', 'AAAAAQAAAAAAAAABAAAAAgAAAAAAAAACAAAAAAAAAADhZd2+D9FQp1nQw6qAh8ETPj3ZCHo6vXo1k+/iMsPXPAAAAAJUC+QAAAAAAgAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAEAAAACAAAAAAAAAABi/B0L0JGythwN1lY0aypo19NHxvLCyO5tBEcCVvwF9w3gtq7/TDZwAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAA==');
+INSERT INTO public.txhistory VALUES ('d714bde56f5d745a06770fbd31eb9751a9988f5be625cfebfeef578767d6bd89', 2, 3, 'AAAAAGL8HQvQkbK2HA3WVjRrKmjX00fG8sLI7m0ERwJW/AX3AAAAZAAAAAAAAAADAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAqojlDeCNjHfCkv8cAKdUJmJvhkAlnQ+INk1dlGv2tLcAAAACVAvkAAAAAAAAAAABVvwF9wAAAEBAc9IDiA8bdVg97qNJIb8Yx9njHJOfouobKw1unDu40/rULoP64v1felhxDEUwSdYvHpdaoIUWIKZA9eQrdBEF', '1xS95W9ddFoGdw+9MeuXUamYj1vmJc/r/u9Xh2fWvYkAAAAAAAAAZAAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAA==', 'AAAAAQAAAAAAAAABAAAAAgAAAAAAAAACAAAAAAAAAACqiOUN4I2Md8KS/xwAp1QmYm+GQCWdD4g2TV2Ua/a0twAAAAJUC+QAAAAAAgAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAEAAAACAAAAAAAAAABi/B0L0JGythwN1lY0aypo19NHxvLCyO5tBEcCVvwF9w3gtqyrQFJwAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAA==');
+INSERT INTO public.txhistory VALUES ('df29b2cead92334dbd7d778ac90e27dfe281cdd979b3a24e228d62e30efafa01', 2, 4, 'AAAAAGL8HQvQkbK2HA3WVjRrKmjX00fG8sLI7m0ERwJW/AX3AAAAZAAAAAAAAAAEAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAsfFywIh+1AAy2mKld4DrYSRUvF9EiyAvD4yiukSUV5oAAAACVAvkAAAAAAAAAAABVvwF9wAAAEDaB9j+85KWEwq2Kcm27EII9PxWWEwQa1Yh9gtxy7OwncgzEwihyqfVStaODWBy+JEjZ6ySL2GbHeLeKkJx44sI', '3ymyzq2SM029fXeKyQ4n3+KBzdl5s6JOIo1i4w76+gEAAAAAAAAAZAAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAA==', 'AAAAAQAAAAAAAAABAAAAAgAAAAAAAAACAAAAAAAAAACx8XLAiH7UADLaYqV3gOthJFS8X0SLIC8PjKK6RJRXmgAAAAJUC+QAAAAAAgAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAEAAAACAAAAAAAAAABi/B0L0JGythwN1lY0aypo19NHxvLCyO5tBEcCVvwF9w3gtqpXNG5wAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAA==');
+INSERT INTO public.txhistory VALUES ('6bbe6b17bb71d7429dc9476fd77c5f9a18b915fd11f2c8b54e9029ae6554f6ef', 3, 1, 'AAAAAOFl3b4P0VCnWdDDqoCHwRM+PdkIejq9ejWT7+Iyw9c8AAAAZAAAAAIAAAABAAAAAAAAAAAAAAABAAAAAAAAAAUAAAAAAAAAAQAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAACqiOUN4I2Md8KS/xwAp1QmYm+GQCWdD4g2TV2Ua/a0twAAAAEAAAAAAAAAATLD1zwAAABATfVpGYYrQJilxLxmEJbz/XeOhzLM1jox/4U6o6R7HUWtwmrtMAHpj3lmFJnF+jRfl74AV3fA1Mo8OU1dVJhaDA==', 'a75rF7tx10KdyUdv13xfmhi5Ff0R8si1TpAprmVU9u8AAAAAAAAAZAAAAAAAAAABAAAAAAAAAAUAAAAAAAAAAA==', 'AAAAAQAAAAIAAAADAAAAAwAAAAAAAAAA4WXdvg/RUKdZ0MOqgIfBEz492Qh6Or16NZPv4jLD1zwAAAACVAvjnAAAAAIAAAAAAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAAABAAAAAwAAAAAAAAAA4WXdvg/RUKdZ0MOqgIfBEz492Qh6Or16NZPv4jLD1zwAAAACVAvjnAAAAAIAAAABAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAAABAAAAAgAAAAMAAAADAAAAAAAAAADhZd2+D9FQp1nQw6qAh8ETPj3ZCHo6vXo1k+/iMsPXPAAAAAJUC+OcAAAAAgAAAAEAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAEAAAADAAAAAAAAAADhZd2+D9FQp1nQw6qAh8ETPj3ZCHo6vXo1k+/iMsPXPAAAAAJUC+OcAAAAAgAAAAEAAAABAAAAAAAAAAAAAAAAAQAAAAAAAAEAAAAAqojlDeCNjHfCkv8cAKdUJmJvhkAlnQ+INk1dlGv2tLcAAAABAAAAAAAAAAA=');
+INSERT INTO public.txhistory VALUES ('88b573ac5441c3934ae6d849c93429bcaa8d83823581b7d72227c8cf06389dd7', 3, 2, 'AAAAALHxcsCIftQAMtpipXeA62EkVLxfRIsgLw+MorpElFeaAAAAZAAAAAIAAAABAAAAAAAAAAAAAAABAAAAAAAAAAYAAAABS0hMAAAAAABnUwkddgJhsE1WC1kSd1enN0ODikIBdVp9KNlUOuPfKH//////////AAAAAAAAAAFElFeaAAAAQF5t+G+v86jAxeXKuSMO5o/A5+qMFT5dPN60bDohBzBFRDV7j3fbt9buXnAkEVAnMVRCDj7VZGRTBlGPpenErgs=', 'iLVzrFRBw5NK5thJyTQpvKqNg4I1gbfXIifIzwY4ndcAAAAAAAAAZAAAAAAAAAABAAAAAAAAAAYAAAAAAAAAAA==', 'AAAAAQAAAAIAAAADAAAAAwAAAAAAAAAAsfFywIh+1AAy2mKld4DrYSRUvF9EiyAvD4yiukSUV5oAAAACVAvjnAAAAAIAAAAAAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAAABAAAAAwAAAAAAAAAAsfFywIh+1AAy2mKld4DrYSRUvF9EiyAvD4yiukSUV5oAAAACVAvjnAAAAAIAAAABAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAAABAAAAAwAAAAAAAAADAAAAAQAAAACx8XLAiH7UADLaYqV3gOthJFS8X0SLIC8PjKK6RJRXmgAAAAFLSEwAAAAAAGdTCR12AmGwTVYLWRJ3V6c3Q4OKQgF1Wn0o2VQ6498oAAAAAAAAAAB//////////wAAAAEAAAAAAAAAAAAAAAMAAAADAAAAAAAAAACx8XLAiH7UADLaYqV3gOthJFS8X0SLIC8PjKK6RJRXmgAAAAJUC+OcAAAAAgAAAAEAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAEAAAADAAAAAAAAAACx8XLAiH7UADLaYqV3gOthJFS8X0SLIC8PjKK6RJRXmgAAAAJUC+OcAAAAAgAAAAEAAAABAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAA==');
+INSERT INTO public.txhistory VALUES ('b5f4d71a8ef136431f9495c3747c70a97a9dc4f33322ed7bd09174975d150ccf', 4, 1, 'AAAAAKqI5Q3gjYx3wpL/HACnVCZib4ZAJZ0PiDZNXZRr9rS3AAAAZAAAAAIAAAABAAAAAAAAAAAAAAABAAAAAAAAAAoAAAAJdGVzdF9kYXRhAAAAAAAAAQAAAAp0ZXN0X3ZhbHVlAAAAAAAAAAAAAWv2tLcAAABAyBAjzvJH8EaYQI07PjKXJN2pGwcwI6HNPbT1+76ehbE/qVeynPzzySF50QNwmBJr8kiZdZzrWmr/EjX7iqurDA==', 'tfTXGo7xNkMflJXDdHxwqXqdxPMzIu170JF0l10VDM8AAAAAAAAAZAAAAAAAAAABAAAAAAAAAAoAAAAAAAAAAA==', 'AAAAAQAAAAIAAAADAAAABAAAAAAAAAAAqojlDeCNjHfCkv8cAKdUJmJvhkAlnQ+INk1dlGv2tLcAAAACVAvjnAAAAAIAAAAAAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAAABAAAABAAAAAAAAAAAqojlDeCNjHfCkv8cAKdUJmJvhkAlnQ+INk1dlGv2tLcAAAACVAvjnAAAAAIAAAABAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAAABAAAAAwAAAAAAAAAEAAAAAwAAAACqiOUN4I2Md8KS/xwAp1QmYm+GQCWdD4g2TV2Ua/a0twAAAAl0ZXN0X2RhdGEAAAAAAAAKdGVzdF92YWx1ZQAAAAAAAAAAAAAAAAADAAAABAAAAAAAAAAAqojlDeCNjHfCkv8cAKdUJmJvhkAlnQ+INk1dlGv2tLcAAAACVAvjnAAAAAIAAAABAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAAABAAAABAAAAAAAAAAAqojlDeCNjHfCkv8cAKdUJmJvhkAlnQ+INk1dlGv2tLcAAAACVAvjnAAAAAIAAAABAAAAAQAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAA=');
+
+
+--
+-- Data for Name: upgradehistory; Type: TABLE DATA; Schema: public; Owner: -
+--
+
+INSERT INTO public.upgradehistory VALUES (2, 1, 'AAAAAQAAAAo=', 'AAAAAA==');
+INSERT INTO public.upgradehistory VALUES (2, 2, 'AAAAAwAAJxA=', 'AAAAAA==');
+
+CREATE VIEW public.assets AS
+( SELECT (((t.assetcode)::text || '-'::text) || (t.issuer)::text) AS assetid,
+  t.assetcode AS code,
+  t.issuer,
+  sum(t.balance) AS total_supply,
+  sum(t.balance) FILTER (WHERE (t.flags = 1)) AS circulating_supply,
+  count(t.accountid) AS holders_count,
+  count(t.accountid) FILTER (WHERE (t.flags = 0)) AS unauthorized_holders_count,
+  max(t.lastmodified) AS last_activity
+  FROM public.trustlines t
+  GROUP BY t.issuer, t.assetcode
+  ORDER BY (count(t.accountid)) DESC)
+UNION
+SELECT 'native'::text AS assetid,
+'XLM'::character varying AS code,
+NULL::character varying AS issuer,
+sum(accounts.balance) AS total_supply,
+sum(accounts.balance) AS circulating_supply,
+count(*) AS holders_count,
+0 AS unauthorized_holders_count,
+max(accounts.lastmodified) AS last_activity
+FROM public.accounts;
+
+--
+-- Name: accountdata accountdata_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY public.accountdata
@@ -626,7 +584,7 @@ ALTER TABLE ONLY public.accountdata
 
 
 --
--- Name: accounts accounts_pkey; Type: CONSTRAINT; Schema: public; Owner: charlie
+-- Name: accounts accounts_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY public.accounts
@@ -634,7 +592,7 @@ ALTER TABLE ONLY public.accounts
 
 
 --
--- Name: ban ban_pkey; Type: CONSTRAINT; Schema: public; Owner: charlie
+-- Name: ban ban_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY public.ban
@@ -642,7 +600,7 @@ ALTER TABLE ONLY public.ban
 
 
 --
--- Name: ledgerheaders ledgerheaders_ledgerseq_key; Type: CONSTRAINT; Schema: public; Owner: charlie
+-- Name: ledgerheaders ledgerheaders_ledgerseq_key; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY public.ledgerheaders
@@ -650,7 +608,7 @@ ALTER TABLE ONLY public.ledgerheaders
 
 
 --
--- Name: ledgerheaders ledgerheaders_pkey; Type: CONSTRAINT; Schema: public; Owner: charlie
+-- Name: ledgerheaders ledgerheaders_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY public.ledgerheaders
@@ -658,7 +616,7 @@ ALTER TABLE ONLY public.ledgerheaders
 
 
 --
--- Name: offers offers_pkey; Type: CONSTRAINT; Schema: public; Owner: charlie
+-- Name: offers offers_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY public.offers
@@ -666,7 +624,7 @@ ALTER TABLE ONLY public.offers
 
 
 --
--- Name: peers peers_pkey; Type: CONSTRAINT; Schema: public; Owner: charlie
+-- Name: peers peers_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY public.peers
@@ -674,7 +632,7 @@ ALTER TABLE ONLY public.peers
 
 
 --
--- Name: publishqueue publishqueue_pkey; Type: CONSTRAINT; Schema: public; Owner: charlie
+-- Name: publishqueue publishqueue_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY public.publishqueue
@@ -682,7 +640,7 @@ ALTER TABLE ONLY public.publishqueue
 
 
 --
--- Name: pubsub pubsub_pkey; Type: CONSTRAINT; Schema: public; Owner: charlie
+-- Name: pubsub pubsub_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY public.pubsub
@@ -690,7 +648,7 @@ ALTER TABLE ONLY public.pubsub
 
 
 --
--- Name: scpquorums scpquorums_pkey; Type: CONSTRAINT; Schema: public; Owner: charlie
+-- Name: scpquorums scpquorums_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY public.scpquorums
@@ -698,7 +656,7 @@ ALTER TABLE ONLY public.scpquorums
 
 
 --
--- Name: signers signers_pkey; Type: CONSTRAINT; Schema: public; Owner: charlie
+-- Name: signers signers_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY public.signers
@@ -706,7 +664,7 @@ ALTER TABLE ONLY public.signers
 
 
 --
--- Name: storestate storestate_pkey; Type: CONSTRAINT; Schema: public; Owner: charlie
+-- Name: storestate storestate_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY public.storestate
@@ -714,7 +672,7 @@ ALTER TABLE ONLY public.storestate
 
 
 --
--- Name: trustlines trustlines_pkey; Type: CONSTRAINT; Schema: public; Owner: charlie
+-- Name: trustlines trustlines_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY public.trustlines
@@ -722,7 +680,7 @@ ALTER TABLE ONLY public.trustlines
 
 
 --
--- Name: txfeehistory txfeehistory_pkey; Type: CONSTRAINT; Schema: public; Owner: charlie
+-- Name: txfeehistory txfeehistory_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY public.txfeehistory
@@ -730,7 +688,7 @@ ALTER TABLE ONLY public.txfeehistory
 
 
 --
--- Name: txhistory txhistory_pkey; Type: CONSTRAINT; Schema: public; Owner: charlie
+-- Name: txhistory txhistory_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY public.txhistory
@@ -738,7 +696,7 @@ ALTER TABLE ONLY public.txhistory
 
 
 --
--- Name: upgradehistory upgradehistory_pkey; Type: CONSTRAINT; Schema: public; Owner: charlie
+-- Name: upgradehistory upgradehistory_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY public.upgradehistory
@@ -746,77 +704,77 @@ ALTER TABLE ONLY public.upgradehistory
 
 
 --
--- Name: accountbalances; Type: INDEX; Schema: public; Owner: charlie
+-- Name: accountbalances; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE INDEX accountbalances ON public.accounts USING btree (balance) WHERE (balance >= 1000000000);
 
 
 --
--- Name: buyingissuerindex; Type: INDEX; Schema: public; Owner: charlie
+-- Name: buyingissuerindex; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE INDEX buyingissuerindex ON public.offers USING btree (buyingissuer);
 
 
 --
--- Name: histbyseq; Type: INDEX; Schema: public; Owner: charlie
+-- Name: histbyseq; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE INDEX histbyseq ON public.txhistory USING btree (ledgerseq);
 
 
 --
--- Name: histfeebyseq; Type: INDEX; Schema: public; Owner: charlie
+-- Name: histfeebyseq; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE INDEX histfeebyseq ON public.txfeehistory USING btree (ledgerseq);
 
 
 --
--- Name: ledgersbyseq; Type: INDEX; Schema: public; Owner: charlie
+-- Name: ledgersbyseq; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE INDEX ledgersbyseq ON public.ledgerheaders USING btree (ledgerseq);
 
 
 --
--- Name: priceindex; Type: INDEX; Schema: public; Owner: charlie
+-- Name: priceindex; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE INDEX priceindex ON public.offers USING btree (price);
 
 
 --
--- Name: scpenvsbyseq; Type: INDEX; Schema: public; Owner: charlie
+-- Name: scpenvsbyseq; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE INDEX scpenvsbyseq ON public.scphistory USING btree (ledgerseq);
 
 
 --
--- Name: scpquorumsbyseq; Type: INDEX; Schema: public; Owner: charlie
+-- Name: scpquorumsbyseq; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE INDEX scpquorumsbyseq ON public.scpquorums USING btree (lastledgerseq);
 
 
 --
--- Name: sellingissuerindex; Type: INDEX; Schema: public; Owner: charlie
+-- Name: sellingissuerindex; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE INDEX sellingissuerindex ON public.offers USING btree (sellingissuer);
 
 
 --
--- Name: signersaccount; Type: INDEX; Schema: public; Owner: charlie
+-- Name: signersaccount; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE INDEX signersaccount ON public.signers USING btree (accountid);
 
 
 --
--- Name: upgradehistbyseq; Type: INDEX; Schema: public; Owner: charlie
+-- Name: upgradehistbyseq; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE INDEX upgradehistbyseq ON public.upgradehistory USING btree (ledgerseq);

--- a/tests/integration/test_db.sql
+++ b/tests/integration/test_db.sql
@@ -2,8 +2,8 @@
 -- PostgreSQL database dump
 --
 
--- Dumped from database version 9.6.9
--- Dumped by pg_dump version 9.6.9
+-- Dumped from database version 9.6.10
+-- Dumped by pg_dump version 9.6.10
 
 SET statement_timeout = 0;
 SET lock_timeout = 0;
@@ -15,74 +15,77 @@ SET check_function_bodies = false;
 SET client_min_messages = warning;
 SET row_security = off;
 
-DROP INDEX IF EXISTS public.upgradehistbyseq;
-DROP INDEX IF EXISTS public.signersaccount;
-DROP INDEX IF EXISTS public.sellingissuerindex;
-DROP INDEX IF EXISTS public.scpquorumsbyseq;
-DROP INDEX IF EXISTS public.scpenvsbyseq;
-DROP INDEX IF EXISTS public.priceindex;
-DROP INDEX IF EXISTS public.ledgersbyseq;
-DROP INDEX IF EXISTS public.histfeebyseq;
-DROP INDEX IF EXISTS public.histbyseq;
-DROP INDEX IF EXISTS public.buyingissuerindex;
-DROP INDEX IF EXISTS public.accountbalances;
-ALTER TABLE IF EXISTS ONLY public.upgradehistory DROP CONSTRAINT IF EXISTS upgradehistory_pkey;
-ALTER TABLE IF EXISTS ONLY public.txhistory DROP CONSTRAINT IF EXISTS txhistory_pkey;
-ALTER TABLE IF EXISTS ONLY public.txfeehistory DROP CONSTRAINT IF EXISTS txfeehistory_pkey;
-ALTER TABLE IF EXISTS ONLY public.trustlines DROP CONSTRAINT IF EXISTS trustlines_pkey;
-ALTER TABLE IF EXISTS ONLY public.storestate DROP CONSTRAINT IF EXISTS storestate_pkey;
-ALTER TABLE IF EXISTS ONLY public.signers DROP CONSTRAINT IF EXISTS signers_pkey;
-ALTER TABLE IF EXISTS ONLY public.scpquorums DROP CONSTRAINT IF EXISTS scpquorums_pkey;
-ALTER TABLE IF EXISTS ONLY public.pubsub DROP CONSTRAINT IF EXISTS pubsub_pkey;
-ALTER TABLE IF EXISTS ONLY public.publishqueue DROP CONSTRAINT IF EXISTS publishqueue_pkey;
-ALTER TABLE IF EXISTS ONLY public.peers DROP CONSTRAINT IF EXISTS peers_pkey;
-ALTER TABLE IF EXISTS ONLY public.offers DROP CONSTRAINT IF EXISTS offers_pkey;
-ALTER TABLE IF EXISTS ONLY public.ledgerheaders DROP CONSTRAINT IF EXISTS ledgerheaders_pkey;
-ALTER TABLE IF EXISTS ONLY public.ledgerheaders DROP CONSTRAINT IF EXISTS ledgerheaders_ledgerseq_key;
-ALTER TABLE IF EXISTS ONLY public.ban DROP CONSTRAINT IF EXISTS ban_pkey;
-ALTER TABLE IF EXISTS ONLY public.accounts DROP CONSTRAINT IF EXISTS accounts_pkey;
-ALTER TABLE IF EXISTS ONLY public.accountdata DROP CONSTRAINT IF EXISTS accountdata_pkey;
-DROP TABLE IF EXISTS public.upgradehistory;
-DROP TABLE IF EXISTS public.txhistory;
-DROP TABLE IF EXISTS public.txfeehistory;
-DROP TABLE IF EXISTS public.trustlines;
-DROP TABLE IF EXISTS public.storestate;
-DROP TABLE IF EXISTS public.signers;
-DROP TABLE IF EXISTS public.scpquorums;
-DROP TABLE IF EXISTS public.scphistory;
-DROP TABLE IF EXISTS public.pubsub;
-DROP TABLE IF EXISTS public.publishqueue;
-DROP TABLE IF EXISTS public.peers;
-DROP TABLE IF EXISTS public.offers;
-DROP TABLE IF EXISTS public.ledgerheaders;
-DROP TABLE IF EXISTS public.ban;
-DROP TABLE IF EXISTS public.accounts;
-DROP TABLE IF EXISTS public.accountdata;
-DROP EXTENSION IF EXISTS plpgsql;
-DROP SCHEMA IF EXISTS public;
+DROP INDEX public.upgradehistbyseq;
+DROP INDEX public.signersaccount;
+DROP INDEX public.sellingissuerindex;
+DROP INDEX public.scpquorumsbyseq;
+DROP INDEX public.scpenvsbyseq;
+DROP INDEX public.priceindex;
+DROP INDEX public.ledgersbyseq;
+DROP INDEX public.histfeebyseq;
+DROP INDEX public.histbyseq;
+DROP INDEX public.buyingissuerindex;
+DROP INDEX public.accountbalances;
+ALTER TABLE ONLY public.upgradehistory DROP CONSTRAINT upgradehistory_pkey;
+ALTER TABLE ONLY public.txhistory DROP CONSTRAINT txhistory_pkey;
+ALTER TABLE ONLY public.txfeehistory DROP CONSTRAINT txfeehistory_pkey;
+ALTER TABLE ONLY public.trustlines DROP CONSTRAINT trustlines_pkey;
+ALTER TABLE ONLY public.storestate DROP CONSTRAINT storestate_pkey;
+ALTER TABLE ONLY public.signers DROP CONSTRAINT signers_pkey;
+ALTER TABLE ONLY public.scpquorums DROP CONSTRAINT scpquorums_pkey;
+ALTER TABLE ONLY public.pubsub DROP CONSTRAINT pubsub_pkey;
+ALTER TABLE ONLY public.publishqueue DROP CONSTRAINT publishqueue_pkey;
+ALTER TABLE ONLY public.peers DROP CONSTRAINT peers_pkey;
+ALTER TABLE ONLY public.offers DROP CONSTRAINT offers_pkey;
+ALTER TABLE ONLY public.ledgerheaders DROP CONSTRAINT ledgerheaders_pkey;
+ALTER TABLE ONLY public.ledgerheaders DROP CONSTRAINT ledgerheaders_ledgerseq_key;
+ALTER TABLE ONLY public.ban DROP CONSTRAINT ban_pkey;
+ALTER TABLE ONLY public.accounts DROP CONSTRAINT accounts_pkey;
+ALTER TABLE ONLY public.accountdata DROP CONSTRAINT accountdata_pkey;
+DROP TABLE public.upgradehistory;
+DROP TABLE public.txhistory;
+DROP TABLE public.txfeehistory;
+DROP TABLE public.storestate;
+DROP TABLE public.signers;
+DROP TABLE public.scpquorums;
+DROP TABLE public.scphistory;
+DROP TABLE public.pubsub;
+DROP TABLE public.publishqueue;
+DROP TABLE public.peers;
+DROP TABLE public.offers;
+DROP TABLE public.ledgerheaders;
+DROP TABLE public.ban;
+DROP VIEW public.assets;
+DROP TABLE public.trustlines;
+DROP TABLE public.accounts;
+DROP TABLE public.accountdata;
+DROP EXTENSION plpgsql;
+DROP SCHEMA public;
 --
--- Name: public; Type: SCHEMA; Schema: -; Owner: -
+-- Name: public; Type: SCHEMA; Schema: -; Owner: charlie
 --
 
 CREATE SCHEMA public;
 
 
+ALTER SCHEMA public OWNER TO charlie;
+
 --
--- Name: SCHEMA public; Type: COMMENT; Schema: -; Owner: -
+-- Name: SCHEMA public; Type: COMMENT; Schema: -; Owner: charlie
 --
 
 COMMENT ON SCHEMA public IS 'standard public schema';
 
 
 --
--- Name: plpgsql; Type: EXTENSION; Schema: -; Owner: -
+-- Name: plpgsql; Type: EXTENSION; Schema: -; Owner: 
 --
 
 CREATE EXTENSION IF NOT EXISTS plpgsql WITH SCHEMA pg_catalog;
 
 
 --
--- Name: EXTENSION plpgsql; Type: COMMENT; Schema: -; Owner: -
+-- Name: EXTENSION plpgsql; Type: COMMENT; Schema: -; Owner: 
 --
 
 COMMENT ON EXTENSION plpgsql IS 'PL/pgSQL procedural language';
@@ -93,7 +96,7 @@ SET default_tablespace = '';
 SET default_with_oids = false;
 
 --
--- Name: accountdata; Type: TABLE; Schema: public; Owner: -
+-- Name: accountdata; Type: TABLE; Schema: public; Owner: charlie
 --
 
 CREATE TABLE public.accountdata (
@@ -104,8 +107,10 @@ CREATE TABLE public.accountdata (
 );
 
 
+ALTER TABLE public.accountdata OWNER TO charlie;
+
 --
--- Name: accounts; Type: TABLE; Schema: public; Owner: -
+-- Name: accounts; Type: TABLE; Schema: public; Owner: charlie
 --
 
 CREATE TABLE public.accounts (
@@ -127,8 +132,64 @@ CREATE TABLE public.accounts (
 );
 
 
+ALTER TABLE public.accounts OWNER TO charlie;
+
 --
--- Name: ban; Type: TABLE; Schema: public; Owner: -
+-- Name: trustlines; Type: TABLE; Schema: public; Owner: charlie
+--
+
+CREATE TABLE public.trustlines (
+    accountid character varying(56) NOT NULL,
+    assettype integer NOT NULL,
+    issuer character varying(56) NOT NULL,
+    assetcode character varying(12) NOT NULL,
+    tlimit bigint NOT NULL,
+    balance bigint NOT NULL,
+    flags integer NOT NULL,
+    lastmodified integer NOT NULL,
+    buyingliabilities bigint,
+    sellingliabilities bigint,
+    CONSTRAINT trustlines_balance_check CHECK ((balance >= 0)),
+    CONSTRAINT trustlines_buyingliabilities_check CHECK ((buyingliabilities >= 0)),
+    CONSTRAINT trustlines_sellingliabilities_check CHECK ((sellingliabilities >= 0)),
+    CONSTRAINT trustlines_tlimit_check CHECK ((tlimit > 0))
+);
+
+
+ALTER TABLE public.trustlines OWNER TO charlie;
+
+--
+-- Name: assets; Type: VIEW; Schema: public; Owner: charlie
+--
+
+CREATE VIEW public.assets AS
+( SELECT (((t.assetcode)::text || '-'::text) || (t.issuer)::text) AS assetid,
+    t.assetcode AS code,
+    t.issuer,
+    sum(t.balance) AS total_supply,
+    sum(t.balance) FILTER (WHERE (t.flags = 1)) AS circulating_supply,
+    count(t.accountid) AS holders_count,
+    count(t.accountid) FILTER (WHERE (t.flags = 0)) AS unauthorized_holders_count,
+    max(t.lastmodified) AS last_activity
+   FROM public.trustlines t
+  GROUP BY t.issuer, t.assetcode
+  ORDER BY (count(t.accountid)) DESC)
+UNION
+ SELECT 'native'::text AS assetid,
+    'XLM'::character varying AS code,
+    NULL::character varying AS issuer,
+    sum(accounts.balance) AS total_supply,
+    sum(accounts.balance) AS circulating_supply,
+    count(*) AS holders_count,
+    0 AS unauthorized_holders_count,
+    max(accounts.lastmodified) AS last_activity
+   FROM public.accounts;
+
+
+ALTER TABLE public.assets OWNER TO charlie;
+
+--
+-- Name: ban; Type: TABLE; Schema: public; Owner: charlie
 --
 
 CREATE TABLE public.ban (
@@ -136,8 +197,10 @@ CREATE TABLE public.ban (
 );
 
 
+ALTER TABLE public.ban OWNER TO charlie;
+
 --
--- Name: ledgerheaders; Type: TABLE; Schema: public; Owner: -
+-- Name: ledgerheaders; Type: TABLE; Schema: public; Owner: charlie
 --
 
 CREATE TABLE public.ledgerheaders (
@@ -152,8 +215,10 @@ CREATE TABLE public.ledgerheaders (
 );
 
 
+ALTER TABLE public.ledgerheaders OWNER TO charlie;
+
 --
--- Name: offers; Type: TABLE; Schema: public; Owner: -
+-- Name: offers; Type: TABLE; Schema: public; Owner: charlie
 --
 
 CREATE TABLE public.offers (
@@ -176,8 +241,10 @@ CREATE TABLE public.offers (
 );
 
 
+ALTER TABLE public.offers OWNER TO charlie;
+
 --
--- Name: peers; Type: TABLE; Schema: public; Owner: -
+-- Name: peers; Type: TABLE; Schema: public; Owner: charlie
 --
 
 CREATE TABLE public.peers (
@@ -191,8 +258,10 @@ CREATE TABLE public.peers (
 );
 
 
+ALTER TABLE public.peers OWNER TO charlie;
+
 --
--- Name: publishqueue; Type: TABLE; Schema: public; Owner: -
+-- Name: publishqueue; Type: TABLE; Schema: public; Owner: charlie
 --
 
 CREATE TABLE public.publishqueue (
@@ -201,8 +270,10 @@ CREATE TABLE public.publishqueue (
 );
 
 
+ALTER TABLE public.publishqueue OWNER TO charlie;
+
 --
--- Name: pubsub; Type: TABLE; Schema: public; Owner: -
+-- Name: pubsub; Type: TABLE; Schema: public; Owner: charlie
 --
 
 CREATE TABLE public.pubsub (
@@ -211,8 +282,10 @@ CREATE TABLE public.pubsub (
 );
 
 
+ALTER TABLE public.pubsub OWNER TO charlie;
+
 --
--- Name: scphistory; Type: TABLE; Schema: public; Owner: -
+-- Name: scphistory; Type: TABLE; Schema: public; Owner: charlie
 --
 
 CREATE TABLE public.scphistory (
@@ -223,8 +296,10 @@ CREATE TABLE public.scphistory (
 );
 
 
+ALTER TABLE public.scphistory OWNER TO charlie;
+
 --
--- Name: scpquorums; Type: TABLE; Schema: public; Owner: -
+-- Name: scpquorums; Type: TABLE; Schema: public; Owner: charlie
 --
 
 CREATE TABLE public.scpquorums (
@@ -235,8 +310,10 @@ CREATE TABLE public.scpquorums (
 );
 
 
+ALTER TABLE public.scpquorums OWNER TO charlie;
+
 --
--- Name: signers; Type: TABLE; Schema: public; Owner: -
+-- Name: signers; Type: TABLE; Schema: public; Owner: charlie
 --
 
 CREATE TABLE public.signers (
@@ -246,8 +323,10 @@ CREATE TABLE public.signers (
 );
 
 
+ALTER TABLE public.signers OWNER TO charlie;
+
 --
--- Name: storestate; Type: TABLE; Schema: public; Owner: -
+-- Name: storestate; Type: TABLE; Schema: public; Owner: charlie
 --
 
 CREATE TABLE public.storestate (
@@ -256,30 +335,10 @@ CREATE TABLE public.storestate (
 );
 
 
---
--- Name: trustlines; Type: TABLE; Schema: public; Owner: -
---
-
-CREATE TABLE public.trustlines (
-    accountid character varying(56) NOT NULL,
-    assettype integer NOT NULL,
-    issuer character varying(56) NOT NULL,
-    assetcode character varying(12) NOT NULL,
-    tlimit bigint NOT NULL,
-    balance bigint NOT NULL,
-    flags integer NOT NULL,
-    lastmodified integer NOT NULL,
-    buyingliabilities bigint,
-    sellingliabilities bigint,
-    CONSTRAINT trustlines_balance_check CHECK ((balance >= 0)),
-    CONSTRAINT trustlines_buyingliabilities_check CHECK ((buyingliabilities >= 0)),
-    CONSTRAINT trustlines_sellingliabilities_check CHECK ((sellingliabilities >= 0)),
-    CONSTRAINT trustlines_tlimit_check CHECK ((tlimit > 0))
-);
-
+ALTER TABLE public.storestate OWNER TO charlie;
 
 --
--- Name: txfeehistory; Type: TABLE; Schema: public; Owner: -
+-- Name: txfeehistory; Type: TABLE; Schema: public; Owner: charlie
 --
 
 CREATE TABLE public.txfeehistory (
@@ -291,8 +350,10 @@ CREATE TABLE public.txfeehistory (
 );
 
 
+ALTER TABLE public.txfeehistory OWNER TO charlie;
+
 --
--- Name: txhistory; Type: TABLE; Schema: public; Owner: -
+-- Name: txhistory; Type: TABLE; Schema: public; Owner: charlie
 --
 
 CREATE TABLE public.txhistory (
@@ -306,8 +367,10 @@ CREATE TABLE public.txhistory (
 );
 
 
+ALTER TABLE public.txhistory OWNER TO charlie;
+
 --
--- Name: upgradehistory; Type: TABLE; Schema: public; Owner: -
+-- Name: upgradehistory; Type: TABLE; Schema: public; Owner: charlie
 --
 
 CREATE TABLE public.upgradehistory (
@@ -319,93 +382,95 @@ CREATE TABLE public.upgradehistory (
 );
 
 
---
--- Data for Name: accountdata; Type: TABLE DATA; Schema: public; Owner: -
---
-
-INSERT INTO public.accountdata VALUES ('GCVIRZIN4CGYY56CSL7RYAFHKQTGE34GIASZ2D4IGZGV3FDL622LPQZT', 'dGVzdF9kYXRh', 'dGVzdF92YWx1ZQ==', 4);
-
+ALTER TABLE public.upgradehistory OWNER TO charlie;
 
 --
--- Data for Name: accounts; Type: TABLE DATA; Schema: public; Owner: -
+-- Data for Name: accountdata; Type: TABLE DATA; Schema: public; Owner: charlie
 --
 
-INSERT INTO public.accounts VALUES ('GBTVGCI5OYBGDMCNKYFVSETXK6TTOQ4DRJBAC5K2PUUNSVB24PPSQ26Q', 10000000000, 8589934592, 0, NULL, '', 'AQAAAA==', 0, 2, NULL, NULL);
-INSERT INTO public.accounts VALUES ('GBRPYHIL2CI3FNQ4BXLFMNDLFJUNPU2HY3ZMFSHONUCEOASW7QC7OX2H', 999999959999999600, 4, 0, NULL, '', 'AQAAAA==', 0, 2, NULL, NULL);
-INSERT INTO public.accounts VALUES ('GDQWLXN6B7IVBJ2Z2DB2VAEHYEJT4POZBB5DVPL2GWJ67YRSYPLTZ6WC', 9999999900, 8589934593, 1, NULL, '', 'AQAAAA==', 0, 3, NULL, NULL);
-INSERT INTO public.accounts VALUES ('GCY7C4WARB7NIABS3JRKK54A5NQSIVF4L5CIWIBPB6GKFOSESRLZVNMZ', 9999999900, 8589934593, 1, NULL, '', 'AQAAAA==', 0, 3, NULL, NULL);
-INSERT INTO public.accounts VALUES ('GCVIRZIN4CGYY56CSL7RYAFHKQTGE34GIASZ2D4IGZGV3FDL622LPQZT', 9999999900, 8589934593, 1, NULL, '', 'AQAAAA==', 0, 4, NULL, NULL);
+INSERT INTO public.accountdata (accountid, dataname, datavalue, lastmodified) VALUES ('GCVIRZIN4CGYY56CSL7RYAFHKQTGE34GIASZ2D4IGZGV3FDL622LPQZT', 'dGVzdF9kYXRh', 'dGVzdF92YWx1ZQ==', 4);
 
 
 --
--- Data for Name: ban; Type: TABLE DATA; Schema: public; Owner: -
+-- Data for Name: accounts; Type: TABLE DATA; Schema: public; Owner: charlie
 --
 
-
-
---
--- Data for Name: ledgerheaders; Type: TABLE DATA; Schema: public; Owner: -
---
-
-INSERT INTO public.ledgerheaders VALUES ('63d98f536ee68d1b27b5b89f23af5311b7569a24faf1403ad0b52b633b07be99', '0000000000000000000000000000000000000000000000000000000000000000', '572a2e32ff248a07b0e70fd1f6d318c1facd20b6cc08c33d5775259868125a16', 1, 0, 'AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABXKi4y/ySKB7DnD9H20xjB+s0gtswIwz1XdSWYaBJaFgAAAAEN4Lazp2QAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAZAX14QAAAABkAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA');
-INSERT INTO public.ledgerheaders VALUES ('564f13f11b354c55be8c84bd5520c745cd6472bb6a4ed224eba4646faf12a4f4', '63d98f536ee68d1b27b5b89f23af5311b7569a24faf1403ad0b52b633b07be99', '8646c7231c878bc770300c1ba5af4f52c43b6956453cb17d53450cc0b7b081c8', 2, 1538142762, 'AAAACmPZj1Nu5o0bJ7W4nyOvUxG3Vpok+vFAOtC1K2M7B76Z6ncT4HcPGyQz1f+yERxTOPhVOTC/nyiF0diQ/7xuz18AAAAAW64yKgAAAAIAAAAIAAAAAQAAAAoAAAAIAAAAAwAAJxAAAAAAc8/NjBwF+qQVB/2llzB2fBzuAqp9gXhlPmjFw7kwsN6GRscjHIeLx3AwDBulr09SxDtpVkU8sX1TRQzAt7CByAAAAAIN4Lazp2QAAAAAAAAAAAGQAAAAAAAAAAAAAAAAAAAAZAX14QAAACcQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA');
-INSERT INTO public.ledgerheaders VALUES ('d279d98759e1dc15a2d41270fc8002a4f425d113b8e63b6ce941e72788de3d97', '564f13f11b354c55be8c84bd5520c745cd6472bb6a4ed224eba4646faf12a4f4', 'e6c74e41149f7b83109389a52be53b99bde3eb7b8b7a847c1c62cd10fd8db4e1', 3, 1538142763, 'AAAAClZPE/EbNUxVvoyEvVUgx0XNZHK7ak7SJOukZG+vEqT0nirxrU8ET1zYDehB0P+znDoFJEAFAEZYF363l52nSz0AAAAAW64yKwAAAAAAAAAASRBtht4qOQAJcqaVqUpYJzsL77s/2Aw2gg7mDSqJYCXmx05BFJ97gxCTiaUr5TuZvePre4t6hHwcYs0Q/Y204QAAAAMN4Lazp2QAAAAAAAAAAAJYAAAAAAAAAAAAAAAAAAAAZAX14QAAACcQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA');
-INSERT INTO public.ledgerheaders VALUES ('d4ad6f562ffb0ccccee85a10f0da3c350ba3f300a23b1e13e54b4bdfae7ae61f', 'd279d98759e1dc15a2d41270fc8002a4f425d113b8e63b6ce941e72788de3d97', 'a60447c6ad9e2ce5e528d1c6703ce26b110e170fe9545018cab82d68030ccff1', 4, 1538142764, 'AAAACtJ52YdZ4dwVotQScPyAAqT0JdETuOY7bOlB5yeI3j2XbfmLFkML0bnopfyhJ7pKU+AHIbntLnXX4bUNjWKn2UEAAAAAW64yLAAAAAAAAAAAHWoMeWgpQkhAJsTZm4K7+1jl4NOUYyotQH+X0GAoDdGmBEfGrZ4s5eUo0cZwPOJrEQ4XD+lUUBjKuC1oAwzP8QAAAAQN4Lazp2QAAAAAAAAAAAK8AAAAAAAAAAAAAAAAAAAAZAX14QAAACcQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA');
+INSERT INTO public.accounts (accountid, balance, seqnum, numsubentries, inflationdest, homedomain, thresholds, flags, lastmodified, buyingliabilities, sellingliabilities) VALUES ('GBTVGCI5OYBGDMCNKYFVSETXK6TTOQ4DRJBAC5K2PUUNSVB24PPSQ26Q', 10000000000, 8589934592, 0, NULL, '', 'AQAAAA==', 0, 2, NULL, NULL);
+INSERT INTO public.accounts (accountid, balance, seqnum, numsubentries, inflationdest, homedomain, thresholds, flags, lastmodified, buyingliabilities, sellingliabilities) VALUES ('GBRPYHIL2CI3FNQ4BXLFMNDLFJUNPU2HY3ZMFSHONUCEOASW7QC7OX2H', 999999959999999600, 4, 0, NULL, '', 'AQAAAA==', 0, 2, NULL, NULL);
+INSERT INTO public.accounts (accountid, balance, seqnum, numsubentries, inflationdest, homedomain, thresholds, flags, lastmodified, buyingliabilities, sellingliabilities) VALUES ('GDQWLXN6B7IVBJ2Z2DB2VAEHYEJT4POZBB5DVPL2GWJ67YRSYPLTZ6WC', 9999999900, 8589934593, 1, NULL, '', 'AQAAAA==', 0, 3, NULL, NULL);
+INSERT INTO public.accounts (accountid, balance, seqnum, numsubentries, inflationdest, homedomain, thresholds, flags, lastmodified, buyingliabilities, sellingliabilities) VALUES ('GCY7C4WARB7NIABS3JRKK54A5NQSIVF4L5CIWIBPB6GKFOSESRLZVNMZ', 9999999900, 8589934593, 1, NULL, '', 'AQAAAA==', 0, 3, NULL, NULL);
+INSERT INTO public.accounts (accountid, balance, seqnum, numsubentries, inflationdest, homedomain, thresholds, flags, lastmodified, buyingliabilities, sellingliabilities) VALUES ('GCVIRZIN4CGYY56CSL7RYAFHKQTGE34GIASZ2D4IGZGV3FDL622LPQZT', 9999999900, 8589934593, 1, NULL, '', 'AQAAAA==', 0, 4, NULL, NULL);
 
 
 --
--- Data for Name: offers; Type: TABLE DATA; Schema: public; Owner: -
+-- Data for Name: ban; Type: TABLE DATA; Schema: public; Owner: charlie
 --
 
 
 
 --
--- Data for Name: peers; Type: TABLE DATA; Schema: public; Owner: -
+-- Data for Name: ledgerheaders; Type: TABLE DATA; Schema: public; Owner: charlie
+--
+
+INSERT INTO public.ledgerheaders (ledgerhash, prevhash, bucketlisthash, ledgerseq, closetime, data) VALUES ('63d98f536ee68d1b27b5b89f23af5311b7569a24faf1403ad0b52b633b07be99', '0000000000000000000000000000000000000000000000000000000000000000', '572a2e32ff248a07b0e70fd1f6d318c1facd20b6cc08c33d5775259868125a16', 1, 0, 'AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABXKi4y/ySKB7DnD9H20xjB+s0gtswIwz1XdSWYaBJaFgAAAAEN4Lazp2QAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAZAX14QAAAABkAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA');
+INSERT INTO public.ledgerheaders (ledgerhash, prevhash, bucketlisthash, ledgerseq, closetime, data) VALUES ('564f13f11b354c55be8c84bd5520c745cd6472bb6a4ed224eba4646faf12a4f4', '63d98f536ee68d1b27b5b89f23af5311b7569a24faf1403ad0b52b633b07be99', '8646c7231c878bc770300c1ba5af4f52c43b6956453cb17d53450cc0b7b081c8', 2, 1538142762, 'AAAACmPZj1Nu5o0bJ7W4nyOvUxG3Vpok+vFAOtC1K2M7B76Z6ncT4HcPGyQz1f+yERxTOPhVOTC/nyiF0diQ/7xuz18AAAAAW64yKgAAAAIAAAAIAAAAAQAAAAoAAAAIAAAAAwAAJxAAAAAAc8/NjBwF+qQVB/2llzB2fBzuAqp9gXhlPmjFw7kwsN6GRscjHIeLx3AwDBulr09SxDtpVkU8sX1TRQzAt7CByAAAAAIN4Lazp2QAAAAAAAAAAAGQAAAAAAAAAAAAAAAAAAAAZAX14QAAACcQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA');
+INSERT INTO public.ledgerheaders (ledgerhash, prevhash, bucketlisthash, ledgerseq, closetime, data) VALUES ('d279d98759e1dc15a2d41270fc8002a4f425d113b8e63b6ce941e72788de3d97', '564f13f11b354c55be8c84bd5520c745cd6472bb6a4ed224eba4646faf12a4f4', 'e6c74e41149f7b83109389a52be53b99bde3eb7b8b7a847c1c62cd10fd8db4e1', 3, 1538142763, 'AAAAClZPE/EbNUxVvoyEvVUgx0XNZHK7ak7SJOukZG+vEqT0nirxrU8ET1zYDehB0P+znDoFJEAFAEZYF363l52nSz0AAAAAW64yKwAAAAAAAAAASRBtht4qOQAJcqaVqUpYJzsL77s/2Aw2gg7mDSqJYCXmx05BFJ97gxCTiaUr5TuZvePre4t6hHwcYs0Q/Y204QAAAAMN4Lazp2QAAAAAAAAAAAJYAAAAAAAAAAAAAAAAAAAAZAX14QAAACcQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA');
+INSERT INTO public.ledgerheaders (ledgerhash, prevhash, bucketlisthash, ledgerseq, closetime, data) VALUES ('d4ad6f562ffb0ccccee85a10f0da3c350ba3f300a23b1e13e54b4bdfae7ae61f', 'd279d98759e1dc15a2d41270fc8002a4f425d113b8e63b6ce941e72788de3d97', 'a60447c6ad9e2ce5e528d1c6703ce26b110e170fe9545018cab82d68030ccff1', 4, 1538142764, 'AAAACtJ52YdZ4dwVotQScPyAAqT0JdETuOY7bOlB5yeI3j2XbfmLFkML0bnopfyhJ7pKU+AHIbntLnXX4bUNjWKn2UEAAAAAW64yLAAAAAAAAAAAHWoMeWgpQkhAJsTZm4K7+1jl4NOUYyotQH+X0GAoDdGmBEfGrZ4s5eUo0cZwPOJrEQ4XD+lUUBjKuC1oAwzP8QAAAAQN4Lazp2QAAAAAAAAAAAK8AAAAAAAAAAAAAAAAAAAAZAX14QAAACcQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA');
+
+
+--
+-- Data for Name: offers; Type: TABLE DATA; Schema: public; Owner: charlie
 --
 
 
 
 --
--- Data for Name: publishqueue; Type: TABLE DATA; Schema: public; Owner: -
+-- Data for Name: peers; Type: TABLE DATA; Schema: public; Owner: charlie
 --
 
 
 
 --
--- Data for Name: pubsub; Type: TABLE DATA; Schema: public; Owner: -
+-- Data for Name: publishqueue; Type: TABLE DATA; Schema: public; Owner: charlie
 --
 
 
 
 --
--- Data for Name: scphistory; Type: TABLE DATA; Schema: public; Owner: -
+-- Data for Name: pubsub; Type: TABLE DATA; Schema: public; Owner: charlie
 --
 
-INSERT INTO public.scphistory VALUES ('GDVV3C2TQKU7CYLLCES5EXJWQSMLJC33J3IKOBHZ6UWJ44ASOJ7OOIVH', 2, 'AAAAAOtdi1OCqfFhaxEl0l02hJi0i3tO0KcE+fUsnnAScn7nAAAAAAAAAAIAAAACAAAAAQAAAEjqdxPgdw8bJDPV/7IRHFM4+FU5ML+fKIXR2JD/vG7PXwAAAABbrjIqAAAAAgAAAAgAAAABAAAACgAAAAgAAAADAAAnEAAAAAAAAAABee12sYKMH2kWScdOhJ4hs74Dos7GHp7m4FMcW+5z4iIAAABADsR1ensZYiV8ncpG3rNGPAA/yPJYCoRR+3Ti8iT352VHKOnU9WvWJz7TwjsDtVwOX1PCbL9rQ1Z73+WiZMzwAQ==');
-INSERT INTO public.scphistory VALUES ('GDVV3C2TQKU7CYLLCES5EXJWQSMLJC33J3IKOBHZ6UWJ44ASOJ7OOIVH', 3, 'AAAAAOtdi1OCqfFhaxEl0l02hJi0i3tO0KcE+fUsnnAScn7nAAAAAAAAAAMAAAACAAAAAQAAADCeKvGtTwRPXNgN6EHQ/7OcOgUkQAUARlgXfreXnadLPQAAAABbrjIrAAAAAAAAAAAAAAABee12sYKMH2kWScdOhJ4hs74Dos7GHp7m4FMcW+5z4iIAAABAgfKkyW4nEbbGP9uuUXXkcc4a3SFE+stxLgEOgS0LWUeNCTnFg5xd/SseHUdUaHhM/9S4T5r5OMPn8/d3cvZcDw==');
-INSERT INTO public.scphistory VALUES ('GDVV3C2TQKU7CYLLCES5EXJWQSMLJC33J3IKOBHZ6UWJ44ASOJ7OOIVH', 4, 'AAAAAOtdi1OCqfFhaxEl0l02hJi0i3tO0KcE+fUsnnAScn7nAAAAAAAAAAQAAAACAAAAAQAAADBt+YsWQwvRueil/KEnukpT4Achue0uddfhtQ2NYqfZQQAAAABbrjIsAAAAAAAAAAAAAAABee12sYKMH2kWScdOhJ4hs74Dos7GHp7m4FMcW+5z4iIAAABA6w1cQstE5RsDGLD3j0LcARECk8cLqOnurVfTd8Htta5lxh9LR7oS+dLJSPnvqUgkaViJoep8IdxNZfvvwGJSCg==');
 
 
 --
--- Data for Name: scpquorums; Type: TABLE DATA; Schema: public; Owner: -
+-- Data for Name: scphistory; Type: TABLE DATA; Schema: public; Owner: charlie
 --
 
-INSERT INTO public.scpquorums VALUES ('79ed76b1828c1f691649c74e849e21b3be03a2cec61e9ee6e0531c5bee73e222', 4, 'AAAAAQAAAAEAAAAA612LU4Kp8WFrESXSXTaEmLSLe07QpwT59SyecBJyfucAAAAA');
-
-
---
--- Data for Name: signers; Type: TABLE DATA; Schema: public; Owner: -
---
-
-INSERT INTO public.signers VALUES ('GDQWLXN6B7IVBJ2Z2DB2VAEHYEJT4POZBB5DVPL2GWJ67YRSYPLTZ6WC', 'GCVIRZIN4CGYY56CSL7RYAFHKQTGE34GIASZ2D4IGZGV3FDL622LPQZT', 1);
+INSERT INTO public.scphistory (nodeid, ledgerseq, envelope) VALUES ('GDVV3C2TQKU7CYLLCES5EXJWQSMLJC33J3IKOBHZ6UWJ44ASOJ7OOIVH', 2, 'AAAAAOtdi1OCqfFhaxEl0l02hJi0i3tO0KcE+fUsnnAScn7nAAAAAAAAAAIAAAACAAAAAQAAAEjqdxPgdw8bJDPV/7IRHFM4+FU5ML+fKIXR2JD/vG7PXwAAAABbrjIqAAAAAgAAAAgAAAABAAAACgAAAAgAAAADAAAnEAAAAAAAAAABee12sYKMH2kWScdOhJ4hs74Dos7GHp7m4FMcW+5z4iIAAABADsR1ensZYiV8ncpG3rNGPAA/yPJYCoRR+3Ti8iT352VHKOnU9WvWJz7TwjsDtVwOX1PCbL9rQ1Z73+WiZMzwAQ==');
+INSERT INTO public.scphistory (nodeid, ledgerseq, envelope) VALUES ('GDVV3C2TQKU7CYLLCES5EXJWQSMLJC33J3IKOBHZ6UWJ44ASOJ7OOIVH', 3, 'AAAAAOtdi1OCqfFhaxEl0l02hJi0i3tO0KcE+fUsnnAScn7nAAAAAAAAAAMAAAACAAAAAQAAADCeKvGtTwRPXNgN6EHQ/7OcOgUkQAUARlgXfreXnadLPQAAAABbrjIrAAAAAAAAAAAAAAABee12sYKMH2kWScdOhJ4hs74Dos7GHp7m4FMcW+5z4iIAAABAgfKkyW4nEbbGP9uuUXXkcc4a3SFE+stxLgEOgS0LWUeNCTnFg5xd/SseHUdUaHhM/9S4T5r5OMPn8/d3cvZcDw==');
+INSERT INTO public.scphistory (nodeid, ledgerseq, envelope) VALUES ('GDVV3C2TQKU7CYLLCES5EXJWQSMLJC33J3IKOBHZ6UWJ44ASOJ7OOIVH', 4, 'AAAAAOtdi1OCqfFhaxEl0l02hJi0i3tO0KcE+fUsnnAScn7nAAAAAAAAAAQAAAACAAAAAQAAADBt+YsWQwvRueil/KEnukpT4Achue0uddfhtQ2NYqfZQQAAAABbrjIsAAAAAAAAAAAAAAABee12sYKMH2kWScdOhJ4hs74Dos7GHp7m4FMcW+5z4iIAAABA6w1cQstE5RsDGLD3j0LcARECk8cLqOnurVfTd8Htta5lxh9LR7oS+dLJSPnvqUgkaViJoep8IdxNZfvvwGJSCg==');
 
 
 --
--- Data for Name: storestate; Type: TABLE DATA; Schema: public; Owner: -
+-- Data for Name: scpquorums; Type: TABLE DATA; Schema: public; Owner: charlie
 --
 
-INSERT INTO public.storestate VALUES ('lastclosedledger                ', 'd4ad6f562ffb0ccccee85a10f0da3c350ba3f300a23b1e13e54b4bdfae7ae61f');
-INSERT INTO public.storestate VALUES ('historyarchivestate             ', '{
+INSERT INTO public.scpquorums (qsethash, lastledgerseq, qset) VALUES ('79ed76b1828c1f691649c74e849e21b3be03a2cec61e9ee6e0531c5bee73e222', 4, 'AAAAAQAAAAEAAAAA612LU4Kp8WFrESXSXTaEmLSLe07QpwT59SyecBJyfucAAAAA');
+
+
+--
+-- Data for Name: signers; Type: TABLE DATA; Schema: public; Owner: charlie
+--
+
+INSERT INTO public.signers (accountid, publickey, weight) VALUES ('GDQWLXN6B7IVBJ2Z2DB2VAEHYEJT4POZBB5DVPL2GWJ67YRSYPLTZ6WC', 'GCVIRZIN4CGYY56CSL7RYAFHKQTGE34GIASZ2D4IGZGV3FDL622LPQZT', 1);
+
+
+--
+-- Data for Name: storestate; Type: TABLE DATA; Schema: public; Owner: charlie
+--
+
+INSERT INTO public.storestate (statename, state) VALUES ('lastclosedledger                ', 'd4ad6f562ffb0ccccee85a10f0da3c350ba3f300a23b1e13e54b4bdfae7ae61f');
+INSERT INTO public.storestate (statename, state) VALUES ('historyarchivestate             ', '{
     "version": 1,
     "server": "v10.0.0",
     "currentLedger": 4,
@@ -490,11 +555,11 @@ INSERT INTO public.storestate VALUES ('historyarchivestate             ', '{
         }
     ]
 }');
-INSERT INTO public.storestate VALUES ('lastscpdata                     ', 'AAAAAgAAAADrXYtTgqnxYWsRJdJdNoSYtIt7TtCnBPn1LJ5wEnJ+5wAAAAAAAAAEAAAAA3ntdrGCjB9pFknHToSeIbO+A6LOxh6e5uBTHFvuc+IiAAAAAQAAADBt+YsWQwvRueil/KEnukpT4Achue0uddfhtQ2NYqfZQQAAAABbrjIsAAAAAAAAAAAAAAABAAAAMG35ixZDC9G56KX8oSe6SlPgByG57S511+G1DY1ip9lBAAAAAFuuMiwAAAAAAAAAAAAAAEB2DBi/Viehmy1h9GcEThlXiGo4GG19klTmUFxWhFKQh33HNaC/9hvAOJ4O8Pt6HXSnVuXRy9rA6Ss1mu+58c8BAAAAAOtdi1OCqfFhaxEl0l02hJi0i3tO0KcE+fUsnnAScn7nAAAAAAAAAAQAAAACAAAAAQAAADBt+YsWQwvRueil/KEnukpT4Achue0uddfhtQ2NYqfZQQAAAABbrjIsAAAAAAAAAAAAAAABee12sYKMH2kWScdOhJ4hs74Dos7GHp7m4FMcW+5z4iIAAABA6w1cQstE5RsDGLD3j0LcARECk8cLqOnurVfTd8Htta5lxh9LR7oS+dLJSPnvqUgkaViJoep8IdxNZfvvwGJSCgAAAAHSedmHWeHcFaLUEnD8gAKk9CXRE7jmO2zpQecniN49lwAAAAEAAAAAqojlDeCNjHfCkv8cAKdUJmJvhkAlnQ+INk1dlGv2tLcAAABkAAAAAgAAAAEAAAAAAAAAAAAAAAEAAAAAAAAACgAAAAl0ZXN0X2RhdGEAAAAAAAABAAAACnRlc3RfdmFsdWUAAAAAAAAAAAABa/a0twAAAEDIECPO8kfwRphAjTs+Mpck3akbBzAjoc09tPX7vp6FsT+pV7Kc/PPJIXnRA3CYEmvySJl1nOtaav8SNfuKq6sMAAAAAQAAAAEAAAABAAAAAOtdi1OCqfFhaxEl0l02hJi0i3tO0KcE+fUsnnAScn7nAAAAAA==');
-INSERT INTO public.storestate VALUES ('databaseschema                  ', '7');
-INSERT INTO public.storestate VALUES ('networkpassphrase               ', 'Test SDF Network ; September 2015');
-INSERT INTO public.storestate VALUES ('forcescponnextlaunch            ', 'false');
-INSERT INTO public.storestate VALUES ('ledgerupgrades                  ', '{
+INSERT INTO public.storestate (statename, state) VALUES ('lastscpdata                     ', 'AAAAAgAAAADrXYtTgqnxYWsRJdJdNoSYtIt7TtCnBPn1LJ5wEnJ+5wAAAAAAAAAEAAAAA3ntdrGCjB9pFknHToSeIbO+A6LOxh6e5uBTHFvuc+IiAAAAAQAAADBt+YsWQwvRueil/KEnukpT4Achue0uddfhtQ2NYqfZQQAAAABbrjIsAAAAAAAAAAAAAAABAAAAMG35ixZDC9G56KX8oSe6SlPgByG57S511+G1DY1ip9lBAAAAAFuuMiwAAAAAAAAAAAAAAEB2DBi/Viehmy1h9GcEThlXiGo4GG19klTmUFxWhFKQh33HNaC/9hvAOJ4O8Pt6HXSnVuXRy9rA6Ss1mu+58c8BAAAAAOtdi1OCqfFhaxEl0l02hJi0i3tO0KcE+fUsnnAScn7nAAAAAAAAAAQAAAACAAAAAQAAADBt+YsWQwvRueil/KEnukpT4Achue0uddfhtQ2NYqfZQQAAAABbrjIsAAAAAAAAAAAAAAABee12sYKMH2kWScdOhJ4hs74Dos7GHp7m4FMcW+5z4iIAAABA6w1cQstE5RsDGLD3j0LcARECk8cLqOnurVfTd8Htta5lxh9LR7oS+dLJSPnvqUgkaViJoep8IdxNZfvvwGJSCgAAAAHSedmHWeHcFaLUEnD8gAKk9CXRE7jmO2zpQecniN49lwAAAAEAAAAAqojlDeCNjHfCkv8cAKdUJmJvhkAlnQ+INk1dlGv2tLcAAABkAAAAAgAAAAEAAAAAAAAAAAAAAAEAAAAAAAAACgAAAAl0ZXN0X2RhdGEAAAAAAAABAAAACnRlc3RfdmFsdWUAAAAAAAAAAAABa/a0twAAAEDIECPO8kfwRphAjTs+Mpck3akbBzAjoc09tPX7vp6FsT+pV7Kc/PPJIXnRA3CYEmvySJl1nOtaav8SNfuKq6sMAAAAAQAAAAEAAAABAAAAAOtdi1OCqfFhaxEl0l02hJi0i3tO0KcE+fUsnnAScn7nAAAAAA==');
+INSERT INTO public.storestate (statename, state) VALUES ('databaseschema                  ', '7');
+INSERT INTO public.storestate (statename, state) VALUES ('networkpassphrase               ', 'Test SDF Network ; September 2015');
+INSERT INTO public.storestate (statename, state) VALUES ('forcescponnextlaunch            ', 'false');
+INSERT INTO public.storestate (statename, state) VALUES ('ledgerupgrades                  ', '{
     "time": 0,
     "version": {
         "has": false
@@ -512,48 +577,48 @@ INSERT INTO public.storestate VALUES ('ledgerupgrades                  ', '{
 
 
 --
--- Data for Name: trustlines; Type: TABLE DATA; Schema: public; Owner: -
+-- Data for Name: trustlines; Type: TABLE DATA; Schema: public; Owner: charlie
 --
 
-INSERT INTO public.trustlines VALUES ('GCY7C4WARB7NIABS3JRKK54A5NQSIVF4L5CIWIBPB6GKFOSESRLZVNMZ', 1, 'GBTVGCI5OYBGDMCNKYFVSETXK6TTOQ4DRJBAC5K2PUUNSVB24PPSQ26Q', 'KHL', 9223372036854775807, 0, 1, 3, NULL, NULL);
-
-
---
--- Data for Name: txfeehistory; Type: TABLE DATA; Schema: public; Owner: -
---
-
-INSERT INTO public.txfeehistory VALUES ('c3bc990f06136ed43088920f58ae2ae034b3075992637d2eeb0a9d351d4eba91', 2, 1, 'AAAAAgAAAAMAAAABAAAAAAAAAABi/B0L0JGythwN1lY0aypo19NHxvLCyO5tBEcCVvwF9w3gtrOnZAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAEAAAACAAAAAAAAAABi/B0L0JGythwN1lY0aypo19NHxvLCyO5tBEcCVvwF9w3gtrOnY/+cAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAA==');
-INSERT INTO public.txfeehistory VALUES ('647646ee4cb26f006f58546fdf0423ebe44fcecd277c12f4983c1e180af1d390', 2, 2, 'AAAAAgAAAAMAAAACAAAAAAAAAABi/B0L0JGythwN1lY0aypo19NHxvLCyO5tBEcCVvwF9w3gtrOnY/+cAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAEAAAACAAAAAAAAAABi/B0L0JGythwN1lY0aypo19NHxvLCyO5tBEcCVvwF9w3gtrOnY/84AAAAAAAAAAIAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAA==');
-INSERT INTO public.txfeehistory VALUES ('d714bde56f5d745a06770fbd31eb9751a9988f5be625cfebfeef578767d6bd89', 2, 3, 'AAAAAgAAAAMAAAACAAAAAAAAAABi/B0L0JGythwN1lY0aypo19NHxvLCyO5tBEcCVvwF9w3gtrOnY/84AAAAAAAAAAIAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAEAAAACAAAAAAAAAABi/B0L0JGythwN1lY0aypo19NHxvLCyO5tBEcCVvwF9w3gtrOnY/7UAAAAAAAAAAMAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAA==');
-INSERT INTO public.txfeehistory VALUES ('df29b2cead92334dbd7d778ac90e27dfe281cdd979b3a24e228d62e30efafa01', 2, 4, 'AAAAAgAAAAMAAAACAAAAAAAAAABi/B0L0JGythwN1lY0aypo19NHxvLCyO5tBEcCVvwF9w3gtrOnY/7UAAAAAAAAAAMAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAEAAAACAAAAAAAAAABi/B0L0JGythwN1lY0aypo19NHxvLCyO5tBEcCVvwF9w3gtrOnY/5wAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAA==');
-INSERT INTO public.txfeehistory VALUES ('6bbe6b17bb71d7429dc9476fd77c5f9a18b915fd11f2c8b54e9029ae6554f6ef', 3, 1, 'AAAAAgAAAAMAAAACAAAAAAAAAADhZd2+D9FQp1nQw6qAh8ETPj3ZCHo6vXo1k+/iMsPXPAAAAAJUC+QAAAAAAgAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAEAAAADAAAAAAAAAADhZd2+D9FQp1nQw6qAh8ETPj3ZCHo6vXo1k+/iMsPXPAAAAAJUC+OcAAAAAgAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAA==');
-INSERT INTO public.txfeehistory VALUES ('88b573ac5441c3934ae6d849c93429bcaa8d83823581b7d72227c8cf06389dd7', 3, 2, 'AAAAAgAAAAMAAAACAAAAAAAAAACx8XLAiH7UADLaYqV3gOthJFS8X0SLIC8PjKK6RJRXmgAAAAJUC+QAAAAAAgAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAEAAAADAAAAAAAAAACx8XLAiH7UADLaYqV3gOthJFS8X0SLIC8PjKK6RJRXmgAAAAJUC+OcAAAAAgAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAA==');
-INSERT INTO public.txfeehistory VALUES ('b5f4d71a8ef136431f9495c3747c70a97a9dc4f33322ed7bd09174975d150ccf', 4, 1, 'AAAAAgAAAAMAAAACAAAAAAAAAACqiOUN4I2Md8KS/xwAp1QmYm+GQCWdD4g2TV2Ua/a0twAAAAJUC+QAAAAAAgAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAEAAAAEAAAAAAAAAACqiOUN4I2Md8KS/xwAp1QmYm+GQCWdD4g2TV2Ua/a0twAAAAJUC+OcAAAAAgAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAA==');
+INSERT INTO public.trustlines (accountid, assettype, issuer, assetcode, tlimit, balance, flags, lastmodified, buyingliabilities, sellingliabilities) VALUES ('GCY7C4WARB7NIABS3JRKK54A5NQSIVF4L5CIWIBPB6GKFOSESRLZVNMZ', 1, 'GBTVGCI5OYBGDMCNKYFVSETXK6TTOQ4DRJBAC5K2PUUNSVB24PPSQ26Q', 'KHL', 9223372036854775807, 0, 1, 3, NULL, NULL);
 
 
 --
--- Data for Name: txhistory; Type: TABLE DATA; Schema: public; Owner: -
+-- Data for Name: txfeehistory; Type: TABLE DATA; Schema: public; Owner: charlie
 --
 
-INSERT INTO public.txhistory VALUES ('c3bc990f06136ed43088920f58ae2ae034b3075992637d2eeb0a9d351d4eba91', 2, 1, 'AAAAAGL8HQvQkbK2HA3WVjRrKmjX00fG8sLI7m0ERwJW/AX3AAAAZAAAAAAAAAABAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAZ1MJHXYCYbBNVgtZEndXpzdDg4pCAXVafSjZVDrj3ygAAAACVAvkAAAAAAAAAAABVvwF9wAAAECtxau60cUj7Xmb5/v7/RJe/SgqWkTSt1qH9hLERe2YcepDcF2FD97zxUpZ6bDbDdLMMrvboV5Gh+k8C29EOtoI', 'w7yZDwYTbtQwiJIPWK4q4DSzB1mSY30u6wqdNR1OupEAAAAAAAAAZAAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAA==', 'AAAAAQAAAAAAAAABAAAAAgAAAAAAAAACAAAAAAAAAABnUwkddgJhsE1WC1kSd1enN0ODikIBdVp9KNlUOuPfKAAAAAJUC+QAAAAAAgAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAEAAAACAAAAAAAAAABi/B0L0JGythwN1lY0aypo19NHxvLCyO5tBEcCVvwF9w3gtrFTWBpwAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAA==');
-INSERT INTO public.txhistory VALUES ('647646ee4cb26f006f58546fdf0423ebe44fcecd277c12f4983c1e180af1d390', 2, 2, 'AAAAAGL8HQvQkbK2HA3WVjRrKmjX00fG8sLI7m0ERwJW/AX3AAAAZAAAAAAAAAACAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAA4WXdvg/RUKdZ0MOqgIfBEz492Qh6Or16NZPv4jLD1zwAAAACVAvkAAAAAAAAAAABVvwF9wAAAEBPmU8p7LrGpKUCz4qQmbxOYYwkfYyKe8ZKtRw6F5hNvD6YpGQAkPEsiCI8N4JrpKnkkHD3cIsYeWexHhCtoiMI', 'ZHZG7kyybwBvWFRv3wQj6+RPzs0nfBL0mDweGArx05AAAAAAAAAAZAAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAA==', 'AAAAAQAAAAAAAAABAAAAAgAAAAAAAAACAAAAAAAAAADhZd2+D9FQp1nQw6qAh8ETPj3ZCHo6vXo1k+/iMsPXPAAAAAJUC+QAAAAAAgAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAEAAAACAAAAAAAAAABi/B0L0JGythwN1lY0aypo19NHxvLCyO5tBEcCVvwF9w3gtq7/TDZwAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAA==');
-INSERT INTO public.txhistory VALUES ('d714bde56f5d745a06770fbd31eb9751a9988f5be625cfebfeef578767d6bd89', 2, 3, 'AAAAAGL8HQvQkbK2HA3WVjRrKmjX00fG8sLI7m0ERwJW/AX3AAAAZAAAAAAAAAADAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAqojlDeCNjHfCkv8cAKdUJmJvhkAlnQ+INk1dlGv2tLcAAAACVAvkAAAAAAAAAAABVvwF9wAAAEBAc9IDiA8bdVg97qNJIb8Yx9njHJOfouobKw1unDu40/rULoP64v1felhxDEUwSdYvHpdaoIUWIKZA9eQrdBEF', '1xS95W9ddFoGdw+9MeuXUamYj1vmJc/r/u9Xh2fWvYkAAAAAAAAAZAAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAA==', 'AAAAAQAAAAAAAAABAAAAAgAAAAAAAAACAAAAAAAAAACqiOUN4I2Md8KS/xwAp1QmYm+GQCWdD4g2TV2Ua/a0twAAAAJUC+QAAAAAAgAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAEAAAACAAAAAAAAAABi/B0L0JGythwN1lY0aypo19NHxvLCyO5tBEcCVvwF9w3gtqyrQFJwAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAA==');
-INSERT INTO public.txhistory VALUES ('df29b2cead92334dbd7d778ac90e27dfe281cdd979b3a24e228d62e30efafa01', 2, 4, 'AAAAAGL8HQvQkbK2HA3WVjRrKmjX00fG8sLI7m0ERwJW/AX3AAAAZAAAAAAAAAAEAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAsfFywIh+1AAy2mKld4DrYSRUvF9EiyAvD4yiukSUV5oAAAACVAvkAAAAAAAAAAABVvwF9wAAAEDaB9j+85KWEwq2Kcm27EII9PxWWEwQa1Yh9gtxy7OwncgzEwihyqfVStaODWBy+JEjZ6ySL2GbHeLeKkJx44sI', '3ymyzq2SM029fXeKyQ4n3+KBzdl5s6JOIo1i4w76+gEAAAAAAAAAZAAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAA==', 'AAAAAQAAAAAAAAABAAAAAgAAAAAAAAACAAAAAAAAAACx8XLAiH7UADLaYqV3gOthJFS8X0SLIC8PjKK6RJRXmgAAAAJUC+QAAAAAAgAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAEAAAACAAAAAAAAAABi/B0L0JGythwN1lY0aypo19NHxvLCyO5tBEcCVvwF9w3gtqpXNG5wAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAA==');
-INSERT INTO public.txhistory VALUES ('6bbe6b17bb71d7429dc9476fd77c5f9a18b915fd11f2c8b54e9029ae6554f6ef', 3, 1, 'AAAAAOFl3b4P0VCnWdDDqoCHwRM+PdkIejq9ejWT7+Iyw9c8AAAAZAAAAAIAAAABAAAAAAAAAAAAAAABAAAAAAAAAAUAAAAAAAAAAQAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAACqiOUN4I2Md8KS/xwAp1QmYm+GQCWdD4g2TV2Ua/a0twAAAAEAAAAAAAAAATLD1zwAAABATfVpGYYrQJilxLxmEJbz/XeOhzLM1jox/4U6o6R7HUWtwmrtMAHpj3lmFJnF+jRfl74AV3fA1Mo8OU1dVJhaDA==', 'a75rF7tx10KdyUdv13xfmhi5Ff0R8si1TpAprmVU9u8AAAAAAAAAZAAAAAAAAAABAAAAAAAAAAUAAAAAAAAAAA==', 'AAAAAQAAAAIAAAADAAAAAwAAAAAAAAAA4WXdvg/RUKdZ0MOqgIfBEz492Qh6Or16NZPv4jLD1zwAAAACVAvjnAAAAAIAAAAAAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAAABAAAAAwAAAAAAAAAA4WXdvg/RUKdZ0MOqgIfBEz492Qh6Or16NZPv4jLD1zwAAAACVAvjnAAAAAIAAAABAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAAABAAAAAgAAAAMAAAADAAAAAAAAAADhZd2+D9FQp1nQw6qAh8ETPj3ZCHo6vXo1k+/iMsPXPAAAAAJUC+OcAAAAAgAAAAEAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAEAAAADAAAAAAAAAADhZd2+D9FQp1nQw6qAh8ETPj3ZCHo6vXo1k+/iMsPXPAAAAAJUC+OcAAAAAgAAAAEAAAABAAAAAAAAAAAAAAAAAQAAAAAAAAEAAAAAqojlDeCNjHfCkv8cAKdUJmJvhkAlnQ+INk1dlGv2tLcAAAABAAAAAAAAAAA=');
-INSERT INTO public.txhistory VALUES ('88b573ac5441c3934ae6d849c93429bcaa8d83823581b7d72227c8cf06389dd7', 3, 2, 'AAAAALHxcsCIftQAMtpipXeA62EkVLxfRIsgLw+MorpElFeaAAAAZAAAAAIAAAABAAAAAAAAAAAAAAABAAAAAAAAAAYAAAABS0hMAAAAAABnUwkddgJhsE1WC1kSd1enN0ODikIBdVp9KNlUOuPfKH//////////AAAAAAAAAAFElFeaAAAAQF5t+G+v86jAxeXKuSMO5o/A5+qMFT5dPN60bDohBzBFRDV7j3fbt9buXnAkEVAnMVRCDj7VZGRTBlGPpenErgs=', 'iLVzrFRBw5NK5thJyTQpvKqNg4I1gbfXIifIzwY4ndcAAAAAAAAAZAAAAAAAAAABAAAAAAAAAAYAAAAAAAAAAA==', 'AAAAAQAAAAIAAAADAAAAAwAAAAAAAAAAsfFywIh+1AAy2mKld4DrYSRUvF9EiyAvD4yiukSUV5oAAAACVAvjnAAAAAIAAAAAAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAAABAAAAAwAAAAAAAAAAsfFywIh+1AAy2mKld4DrYSRUvF9EiyAvD4yiukSUV5oAAAACVAvjnAAAAAIAAAABAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAAABAAAAAwAAAAAAAAADAAAAAQAAAACx8XLAiH7UADLaYqV3gOthJFS8X0SLIC8PjKK6RJRXmgAAAAFLSEwAAAAAAGdTCR12AmGwTVYLWRJ3V6c3Q4OKQgF1Wn0o2VQ6498oAAAAAAAAAAB//////////wAAAAEAAAAAAAAAAAAAAAMAAAADAAAAAAAAAACx8XLAiH7UADLaYqV3gOthJFS8X0SLIC8PjKK6RJRXmgAAAAJUC+OcAAAAAgAAAAEAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAEAAAADAAAAAAAAAACx8XLAiH7UADLaYqV3gOthJFS8X0SLIC8PjKK6RJRXmgAAAAJUC+OcAAAAAgAAAAEAAAABAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAA==');
-INSERT INTO public.txhistory VALUES ('b5f4d71a8ef136431f9495c3747c70a97a9dc4f33322ed7bd09174975d150ccf', 4, 1, 'AAAAAKqI5Q3gjYx3wpL/HACnVCZib4ZAJZ0PiDZNXZRr9rS3AAAAZAAAAAIAAAABAAAAAAAAAAAAAAABAAAAAAAAAAoAAAAJdGVzdF9kYXRhAAAAAAAAAQAAAAp0ZXN0X3ZhbHVlAAAAAAAAAAAAAWv2tLcAAABAyBAjzvJH8EaYQI07PjKXJN2pGwcwI6HNPbT1+76ehbE/qVeynPzzySF50QNwmBJr8kiZdZzrWmr/EjX7iqurDA==', 'tfTXGo7xNkMflJXDdHxwqXqdxPMzIu170JF0l10VDM8AAAAAAAAAZAAAAAAAAAABAAAAAAAAAAoAAAAAAAAAAA==', 'AAAAAQAAAAIAAAADAAAABAAAAAAAAAAAqojlDeCNjHfCkv8cAKdUJmJvhkAlnQ+INk1dlGv2tLcAAAACVAvjnAAAAAIAAAAAAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAAABAAAABAAAAAAAAAAAqojlDeCNjHfCkv8cAKdUJmJvhkAlnQ+INk1dlGv2tLcAAAACVAvjnAAAAAIAAAABAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAAABAAAAAwAAAAAAAAAEAAAAAwAAAACqiOUN4I2Md8KS/xwAp1QmYm+GQCWdD4g2TV2Ua/a0twAAAAl0ZXN0X2RhdGEAAAAAAAAKdGVzdF92YWx1ZQAAAAAAAAAAAAAAAAADAAAABAAAAAAAAAAAqojlDeCNjHfCkv8cAKdUJmJvhkAlnQ+INk1dlGv2tLcAAAACVAvjnAAAAAIAAAABAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAAABAAAABAAAAAAAAAAAqojlDeCNjHfCkv8cAKdUJmJvhkAlnQ+INk1dlGv2tLcAAAACVAvjnAAAAAIAAAABAAAAAQAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAA=');
-
-
---
--- Data for Name: upgradehistory; Type: TABLE DATA; Schema: public; Owner: -
---
-
-INSERT INTO public.upgradehistory VALUES (2, 1, 'AAAAAQAAAAo=', 'AAAAAA==');
-INSERT INTO public.upgradehistory VALUES (2, 2, 'AAAAAwAAJxA=', 'AAAAAA==');
+INSERT INTO public.txfeehistory (txid, ledgerseq, txindex, txchanges) VALUES ('c3bc990f06136ed43088920f58ae2ae034b3075992637d2eeb0a9d351d4eba91', 2, 1, 'AAAAAgAAAAMAAAABAAAAAAAAAABi/B0L0JGythwN1lY0aypo19NHxvLCyO5tBEcCVvwF9w3gtrOnZAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAEAAAACAAAAAAAAAABi/B0L0JGythwN1lY0aypo19NHxvLCyO5tBEcCVvwF9w3gtrOnY/+cAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAA==');
+INSERT INTO public.txfeehistory (txid, ledgerseq, txindex, txchanges) VALUES ('647646ee4cb26f006f58546fdf0423ebe44fcecd277c12f4983c1e180af1d390', 2, 2, 'AAAAAgAAAAMAAAACAAAAAAAAAABi/B0L0JGythwN1lY0aypo19NHxvLCyO5tBEcCVvwF9w3gtrOnY/+cAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAEAAAACAAAAAAAAAABi/B0L0JGythwN1lY0aypo19NHxvLCyO5tBEcCVvwF9w3gtrOnY/84AAAAAAAAAAIAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAA==');
+INSERT INTO public.txfeehistory (txid, ledgerseq, txindex, txchanges) VALUES ('d714bde56f5d745a06770fbd31eb9751a9988f5be625cfebfeef578767d6bd89', 2, 3, 'AAAAAgAAAAMAAAACAAAAAAAAAABi/B0L0JGythwN1lY0aypo19NHxvLCyO5tBEcCVvwF9w3gtrOnY/84AAAAAAAAAAIAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAEAAAACAAAAAAAAAABi/B0L0JGythwN1lY0aypo19NHxvLCyO5tBEcCVvwF9w3gtrOnY/7UAAAAAAAAAAMAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAA==');
+INSERT INTO public.txfeehistory (txid, ledgerseq, txindex, txchanges) VALUES ('df29b2cead92334dbd7d778ac90e27dfe281cdd979b3a24e228d62e30efafa01', 2, 4, 'AAAAAgAAAAMAAAACAAAAAAAAAABi/B0L0JGythwN1lY0aypo19NHxvLCyO5tBEcCVvwF9w3gtrOnY/7UAAAAAAAAAAMAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAEAAAACAAAAAAAAAABi/B0L0JGythwN1lY0aypo19NHxvLCyO5tBEcCVvwF9w3gtrOnY/5wAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAA==');
+INSERT INTO public.txfeehistory (txid, ledgerseq, txindex, txchanges) VALUES ('6bbe6b17bb71d7429dc9476fd77c5f9a18b915fd11f2c8b54e9029ae6554f6ef', 3, 1, 'AAAAAgAAAAMAAAACAAAAAAAAAADhZd2+D9FQp1nQw6qAh8ETPj3ZCHo6vXo1k+/iMsPXPAAAAAJUC+QAAAAAAgAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAEAAAADAAAAAAAAAADhZd2+D9FQp1nQw6qAh8ETPj3ZCHo6vXo1k+/iMsPXPAAAAAJUC+OcAAAAAgAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAA==');
+INSERT INTO public.txfeehistory (txid, ledgerseq, txindex, txchanges) VALUES ('88b573ac5441c3934ae6d849c93429bcaa8d83823581b7d72227c8cf06389dd7', 3, 2, 'AAAAAgAAAAMAAAACAAAAAAAAAACx8XLAiH7UADLaYqV3gOthJFS8X0SLIC8PjKK6RJRXmgAAAAJUC+QAAAAAAgAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAEAAAADAAAAAAAAAACx8XLAiH7UADLaYqV3gOthJFS8X0SLIC8PjKK6RJRXmgAAAAJUC+OcAAAAAgAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAA==');
+INSERT INTO public.txfeehistory (txid, ledgerseq, txindex, txchanges) VALUES ('b5f4d71a8ef136431f9495c3747c70a97a9dc4f33322ed7bd09174975d150ccf', 4, 1, 'AAAAAgAAAAMAAAACAAAAAAAAAACqiOUN4I2Md8KS/xwAp1QmYm+GQCWdD4g2TV2Ua/a0twAAAAJUC+QAAAAAAgAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAEAAAAEAAAAAAAAAACqiOUN4I2Md8KS/xwAp1QmYm+GQCWdD4g2TV2Ua/a0twAAAAJUC+OcAAAAAgAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAA==');
 
 
 --
--- Name: accountdata accountdata_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Data for Name: txhistory; Type: TABLE DATA; Schema: public; Owner: charlie
+--
+
+INSERT INTO public.txhistory (txid, ledgerseq, txindex, txbody, txresult, txmeta) VALUES ('c3bc990f06136ed43088920f58ae2ae034b3075992637d2eeb0a9d351d4eba91', 2, 1, 'AAAAAGL8HQvQkbK2HA3WVjRrKmjX00fG8sLI7m0ERwJW/AX3AAAAZAAAAAAAAAABAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAZ1MJHXYCYbBNVgtZEndXpzdDg4pCAXVafSjZVDrj3ygAAAACVAvkAAAAAAAAAAABVvwF9wAAAECtxau60cUj7Xmb5/v7/RJe/SgqWkTSt1qH9hLERe2YcepDcF2FD97zxUpZ6bDbDdLMMrvboV5Gh+k8C29EOtoI', 'w7yZDwYTbtQwiJIPWK4q4DSzB1mSY30u6wqdNR1OupEAAAAAAAAAZAAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAA==', 'AAAAAQAAAAAAAAABAAAAAgAAAAAAAAACAAAAAAAAAABnUwkddgJhsE1WC1kSd1enN0ODikIBdVp9KNlUOuPfKAAAAAJUC+QAAAAAAgAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAEAAAACAAAAAAAAAABi/B0L0JGythwN1lY0aypo19NHxvLCyO5tBEcCVvwF9w3gtrFTWBpwAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAA==');
+INSERT INTO public.txhistory (txid, ledgerseq, txindex, txbody, txresult, txmeta) VALUES ('647646ee4cb26f006f58546fdf0423ebe44fcecd277c12f4983c1e180af1d390', 2, 2, 'AAAAAGL8HQvQkbK2HA3WVjRrKmjX00fG8sLI7m0ERwJW/AX3AAAAZAAAAAAAAAACAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAA4WXdvg/RUKdZ0MOqgIfBEz492Qh6Or16NZPv4jLD1zwAAAACVAvkAAAAAAAAAAABVvwF9wAAAEBPmU8p7LrGpKUCz4qQmbxOYYwkfYyKe8ZKtRw6F5hNvD6YpGQAkPEsiCI8N4JrpKnkkHD3cIsYeWexHhCtoiMI', 'ZHZG7kyybwBvWFRv3wQj6+RPzs0nfBL0mDweGArx05AAAAAAAAAAZAAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAA==', 'AAAAAQAAAAAAAAABAAAAAgAAAAAAAAACAAAAAAAAAADhZd2+D9FQp1nQw6qAh8ETPj3ZCHo6vXo1k+/iMsPXPAAAAAJUC+QAAAAAAgAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAEAAAACAAAAAAAAAABi/B0L0JGythwN1lY0aypo19NHxvLCyO5tBEcCVvwF9w3gtq7/TDZwAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAA==');
+INSERT INTO public.txhistory (txid, ledgerseq, txindex, txbody, txresult, txmeta) VALUES ('d714bde56f5d745a06770fbd31eb9751a9988f5be625cfebfeef578767d6bd89', 2, 3, 'AAAAAGL8HQvQkbK2HA3WVjRrKmjX00fG8sLI7m0ERwJW/AX3AAAAZAAAAAAAAAADAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAqojlDeCNjHfCkv8cAKdUJmJvhkAlnQ+INk1dlGv2tLcAAAACVAvkAAAAAAAAAAABVvwF9wAAAEBAc9IDiA8bdVg97qNJIb8Yx9njHJOfouobKw1unDu40/rULoP64v1felhxDEUwSdYvHpdaoIUWIKZA9eQrdBEF', '1xS95W9ddFoGdw+9MeuXUamYj1vmJc/r/u9Xh2fWvYkAAAAAAAAAZAAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAA==', 'AAAAAQAAAAAAAAABAAAAAgAAAAAAAAACAAAAAAAAAACqiOUN4I2Md8KS/xwAp1QmYm+GQCWdD4g2TV2Ua/a0twAAAAJUC+QAAAAAAgAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAEAAAACAAAAAAAAAABi/B0L0JGythwN1lY0aypo19NHxvLCyO5tBEcCVvwF9w3gtqyrQFJwAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAA==');
+INSERT INTO public.txhistory (txid, ledgerseq, txindex, txbody, txresult, txmeta) VALUES ('df29b2cead92334dbd7d778ac90e27dfe281cdd979b3a24e228d62e30efafa01', 2, 4, 'AAAAAGL8HQvQkbK2HA3WVjRrKmjX00fG8sLI7m0ERwJW/AX3AAAAZAAAAAAAAAAEAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAsfFywIh+1AAy2mKld4DrYSRUvF9EiyAvD4yiukSUV5oAAAACVAvkAAAAAAAAAAABVvwF9wAAAEDaB9j+85KWEwq2Kcm27EII9PxWWEwQa1Yh9gtxy7OwncgzEwihyqfVStaODWBy+JEjZ6ySL2GbHeLeKkJx44sI', '3ymyzq2SM029fXeKyQ4n3+KBzdl5s6JOIo1i4w76+gEAAAAAAAAAZAAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAA==', 'AAAAAQAAAAAAAAABAAAAAgAAAAAAAAACAAAAAAAAAACx8XLAiH7UADLaYqV3gOthJFS8X0SLIC8PjKK6RJRXmgAAAAJUC+QAAAAAAgAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAEAAAACAAAAAAAAAABi/B0L0JGythwN1lY0aypo19NHxvLCyO5tBEcCVvwF9w3gtqpXNG5wAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAA==');
+INSERT INTO public.txhistory (txid, ledgerseq, txindex, txbody, txresult, txmeta) VALUES ('6bbe6b17bb71d7429dc9476fd77c5f9a18b915fd11f2c8b54e9029ae6554f6ef', 3, 1, 'AAAAAOFl3b4P0VCnWdDDqoCHwRM+PdkIejq9ejWT7+Iyw9c8AAAAZAAAAAIAAAABAAAAAAAAAAAAAAABAAAAAAAAAAUAAAAAAAAAAQAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAACqiOUN4I2Md8KS/xwAp1QmYm+GQCWdD4g2TV2Ua/a0twAAAAEAAAAAAAAAATLD1zwAAABATfVpGYYrQJilxLxmEJbz/XeOhzLM1jox/4U6o6R7HUWtwmrtMAHpj3lmFJnF+jRfl74AV3fA1Mo8OU1dVJhaDA==', 'a75rF7tx10KdyUdv13xfmhi5Ff0R8si1TpAprmVU9u8AAAAAAAAAZAAAAAAAAAABAAAAAAAAAAUAAAAAAAAAAA==', 'AAAAAQAAAAIAAAADAAAAAwAAAAAAAAAA4WXdvg/RUKdZ0MOqgIfBEz492Qh6Or16NZPv4jLD1zwAAAACVAvjnAAAAAIAAAAAAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAAABAAAAAwAAAAAAAAAA4WXdvg/RUKdZ0MOqgIfBEz492Qh6Or16NZPv4jLD1zwAAAACVAvjnAAAAAIAAAABAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAAABAAAAAgAAAAMAAAADAAAAAAAAAADhZd2+D9FQp1nQw6qAh8ETPj3ZCHo6vXo1k+/iMsPXPAAAAAJUC+OcAAAAAgAAAAEAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAEAAAADAAAAAAAAAADhZd2+D9FQp1nQw6qAh8ETPj3ZCHo6vXo1k+/iMsPXPAAAAAJUC+OcAAAAAgAAAAEAAAABAAAAAAAAAAAAAAAAAQAAAAAAAAEAAAAAqojlDeCNjHfCkv8cAKdUJmJvhkAlnQ+INk1dlGv2tLcAAAABAAAAAAAAAAA=');
+INSERT INTO public.txhistory (txid, ledgerseq, txindex, txbody, txresult, txmeta) VALUES ('88b573ac5441c3934ae6d849c93429bcaa8d83823581b7d72227c8cf06389dd7', 3, 2, 'AAAAALHxcsCIftQAMtpipXeA62EkVLxfRIsgLw+MorpElFeaAAAAZAAAAAIAAAABAAAAAAAAAAAAAAABAAAAAAAAAAYAAAABS0hMAAAAAABnUwkddgJhsE1WC1kSd1enN0ODikIBdVp9KNlUOuPfKH//////////AAAAAAAAAAFElFeaAAAAQF5t+G+v86jAxeXKuSMO5o/A5+qMFT5dPN60bDohBzBFRDV7j3fbt9buXnAkEVAnMVRCDj7VZGRTBlGPpenErgs=', 'iLVzrFRBw5NK5thJyTQpvKqNg4I1gbfXIifIzwY4ndcAAAAAAAAAZAAAAAAAAAABAAAAAAAAAAYAAAAAAAAAAA==', 'AAAAAQAAAAIAAAADAAAAAwAAAAAAAAAAsfFywIh+1AAy2mKld4DrYSRUvF9EiyAvD4yiukSUV5oAAAACVAvjnAAAAAIAAAAAAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAAABAAAAAwAAAAAAAAAAsfFywIh+1AAy2mKld4DrYSRUvF9EiyAvD4yiukSUV5oAAAACVAvjnAAAAAIAAAABAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAAABAAAAAwAAAAAAAAADAAAAAQAAAACx8XLAiH7UADLaYqV3gOthJFS8X0SLIC8PjKK6RJRXmgAAAAFLSEwAAAAAAGdTCR12AmGwTVYLWRJ3V6c3Q4OKQgF1Wn0o2VQ6498oAAAAAAAAAAB//////////wAAAAEAAAAAAAAAAAAAAAMAAAADAAAAAAAAAACx8XLAiH7UADLaYqV3gOthJFS8X0SLIC8PjKK6RJRXmgAAAAJUC+OcAAAAAgAAAAEAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAEAAAADAAAAAAAAAACx8XLAiH7UADLaYqV3gOthJFS8X0SLIC8PjKK6RJRXmgAAAAJUC+OcAAAAAgAAAAEAAAABAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAA==');
+INSERT INTO public.txhistory (txid, ledgerseq, txindex, txbody, txresult, txmeta) VALUES ('b5f4d71a8ef136431f9495c3747c70a97a9dc4f33322ed7bd09174975d150ccf', 4, 1, 'AAAAAKqI5Q3gjYx3wpL/HACnVCZib4ZAJZ0PiDZNXZRr9rS3AAAAZAAAAAIAAAABAAAAAAAAAAAAAAABAAAAAAAAAAoAAAAJdGVzdF9kYXRhAAAAAAAAAQAAAAp0ZXN0X3ZhbHVlAAAAAAAAAAAAAWv2tLcAAABAyBAjzvJH8EaYQI07PjKXJN2pGwcwI6HNPbT1+76ehbE/qVeynPzzySF50QNwmBJr8kiZdZzrWmr/EjX7iqurDA==', 'tfTXGo7xNkMflJXDdHxwqXqdxPMzIu170JF0l10VDM8AAAAAAAAAZAAAAAAAAAABAAAAAAAAAAoAAAAAAAAAAA==', 'AAAAAQAAAAIAAAADAAAABAAAAAAAAAAAqojlDeCNjHfCkv8cAKdUJmJvhkAlnQ+INk1dlGv2tLcAAAACVAvjnAAAAAIAAAAAAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAAABAAAABAAAAAAAAAAAqojlDeCNjHfCkv8cAKdUJmJvhkAlnQ+INk1dlGv2tLcAAAACVAvjnAAAAAIAAAABAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAAABAAAAAwAAAAAAAAAEAAAAAwAAAACqiOUN4I2Md8KS/xwAp1QmYm+GQCWdD4g2TV2Ua/a0twAAAAl0ZXN0X2RhdGEAAAAAAAAKdGVzdF92YWx1ZQAAAAAAAAAAAAAAAAADAAAABAAAAAAAAAAAqojlDeCNjHfCkv8cAKdUJmJvhkAlnQ+INk1dlGv2tLcAAAACVAvjnAAAAAIAAAABAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAAABAAAABAAAAAAAAAAAqojlDeCNjHfCkv8cAKdUJmJvhkAlnQ+INk1dlGv2tLcAAAACVAvjnAAAAAIAAAABAAAAAQAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAA=');
+
+
+--
+-- Data for Name: upgradehistory; Type: TABLE DATA; Schema: public; Owner: charlie
+--
+
+INSERT INTO public.upgradehistory (ledgerseq, upgradeindex, upgrade, changes) VALUES (2, 1, 'AAAAAQAAAAo=', 'AAAAAA==');
+INSERT INTO public.upgradehistory (ledgerseq, upgradeindex, upgrade, changes) VALUES (2, 2, 'AAAAAwAAJxA=', 'AAAAAA==');
+
+
+--
+-- Name: accountdata accountdata_pkey; Type: CONSTRAINT; Schema: public; Owner: charlie
 --
 
 ALTER TABLE ONLY public.accountdata
@@ -561,7 +626,7 @@ ALTER TABLE ONLY public.accountdata
 
 
 --
--- Name: accounts accounts_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: accounts accounts_pkey; Type: CONSTRAINT; Schema: public; Owner: charlie
 --
 
 ALTER TABLE ONLY public.accounts
@@ -569,7 +634,7 @@ ALTER TABLE ONLY public.accounts
 
 
 --
--- Name: ban ban_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: ban ban_pkey; Type: CONSTRAINT; Schema: public; Owner: charlie
 --
 
 ALTER TABLE ONLY public.ban
@@ -577,7 +642,7 @@ ALTER TABLE ONLY public.ban
 
 
 --
--- Name: ledgerheaders ledgerheaders_ledgerseq_key; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: ledgerheaders ledgerheaders_ledgerseq_key; Type: CONSTRAINT; Schema: public; Owner: charlie
 --
 
 ALTER TABLE ONLY public.ledgerheaders
@@ -585,7 +650,7 @@ ALTER TABLE ONLY public.ledgerheaders
 
 
 --
--- Name: ledgerheaders ledgerheaders_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: ledgerheaders ledgerheaders_pkey; Type: CONSTRAINT; Schema: public; Owner: charlie
 --
 
 ALTER TABLE ONLY public.ledgerheaders
@@ -593,7 +658,7 @@ ALTER TABLE ONLY public.ledgerheaders
 
 
 --
--- Name: offers offers_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: offers offers_pkey; Type: CONSTRAINT; Schema: public; Owner: charlie
 --
 
 ALTER TABLE ONLY public.offers
@@ -601,7 +666,7 @@ ALTER TABLE ONLY public.offers
 
 
 --
--- Name: peers peers_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: peers peers_pkey; Type: CONSTRAINT; Schema: public; Owner: charlie
 --
 
 ALTER TABLE ONLY public.peers
@@ -609,7 +674,7 @@ ALTER TABLE ONLY public.peers
 
 
 --
--- Name: publishqueue publishqueue_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: publishqueue publishqueue_pkey; Type: CONSTRAINT; Schema: public; Owner: charlie
 --
 
 ALTER TABLE ONLY public.publishqueue
@@ -617,7 +682,7 @@ ALTER TABLE ONLY public.publishqueue
 
 
 --
--- Name: pubsub pubsub_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: pubsub pubsub_pkey; Type: CONSTRAINT; Schema: public; Owner: charlie
 --
 
 ALTER TABLE ONLY public.pubsub
@@ -625,7 +690,7 @@ ALTER TABLE ONLY public.pubsub
 
 
 --
--- Name: scpquorums scpquorums_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: scpquorums scpquorums_pkey; Type: CONSTRAINT; Schema: public; Owner: charlie
 --
 
 ALTER TABLE ONLY public.scpquorums
@@ -633,7 +698,7 @@ ALTER TABLE ONLY public.scpquorums
 
 
 --
--- Name: signers signers_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: signers signers_pkey; Type: CONSTRAINT; Schema: public; Owner: charlie
 --
 
 ALTER TABLE ONLY public.signers
@@ -641,7 +706,7 @@ ALTER TABLE ONLY public.signers
 
 
 --
--- Name: storestate storestate_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: storestate storestate_pkey; Type: CONSTRAINT; Schema: public; Owner: charlie
 --
 
 ALTER TABLE ONLY public.storestate
@@ -649,7 +714,7 @@ ALTER TABLE ONLY public.storestate
 
 
 --
--- Name: trustlines trustlines_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: trustlines trustlines_pkey; Type: CONSTRAINT; Schema: public; Owner: charlie
 --
 
 ALTER TABLE ONLY public.trustlines
@@ -657,7 +722,7 @@ ALTER TABLE ONLY public.trustlines
 
 
 --
--- Name: txfeehistory txfeehistory_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: txfeehistory txfeehistory_pkey; Type: CONSTRAINT; Schema: public; Owner: charlie
 --
 
 ALTER TABLE ONLY public.txfeehistory
@@ -665,7 +730,7 @@ ALTER TABLE ONLY public.txfeehistory
 
 
 --
--- Name: txhistory txhistory_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: txhistory txhistory_pkey; Type: CONSTRAINT; Schema: public; Owner: charlie
 --
 
 ALTER TABLE ONLY public.txhistory
@@ -673,7 +738,7 @@ ALTER TABLE ONLY public.txhistory
 
 
 --
--- Name: upgradehistory upgradehistory_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: upgradehistory upgradehistory_pkey; Type: CONSTRAINT; Schema: public; Owner: charlie
 --
 
 ALTER TABLE ONLY public.upgradehistory
@@ -681,77 +746,77 @@ ALTER TABLE ONLY public.upgradehistory
 
 
 --
--- Name: accountbalances; Type: INDEX; Schema: public; Owner: -
+-- Name: accountbalances; Type: INDEX; Schema: public; Owner: charlie
 --
 
 CREATE INDEX accountbalances ON public.accounts USING btree (balance) WHERE (balance >= 1000000000);
 
 
 --
--- Name: buyingissuerindex; Type: INDEX; Schema: public; Owner: -
+-- Name: buyingissuerindex; Type: INDEX; Schema: public; Owner: charlie
 --
 
 CREATE INDEX buyingissuerindex ON public.offers USING btree (buyingissuer);
 
 
 --
--- Name: histbyseq; Type: INDEX; Schema: public; Owner: -
+-- Name: histbyseq; Type: INDEX; Schema: public; Owner: charlie
 --
 
 CREATE INDEX histbyseq ON public.txhistory USING btree (ledgerseq);
 
 
 --
--- Name: histfeebyseq; Type: INDEX; Schema: public; Owner: -
+-- Name: histfeebyseq; Type: INDEX; Schema: public; Owner: charlie
 --
 
 CREATE INDEX histfeebyseq ON public.txfeehistory USING btree (ledgerseq);
 
 
 --
--- Name: ledgersbyseq; Type: INDEX; Schema: public; Owner: -
+-- Name: ledgersbyseq; Type: INDEX; Schema: public; Owner: charlie
 --
 
 CREATE INDEX ledgersbyseq ON public.ledgerheaders USING btree (ledgerseq);
 
 
 --
--- Name: priceindex; Type: INDEX; Schema: public; Owner: -
+-- Name: priceindex; Type: INDEX; Schema: public; Owner: charlie
 --
 
 CREATE INDEX priceindex ON public.offers USING btree (price);
 
 
 --
--- Name: scpenvsbyseq; Type: INDEX; Schema: public; Owner: -
+-- Name: scpenvsbyseq; Type: INDEX; Schema: public; Owner: charlie
 --
 
 CREATE INDEX scpenvsbyseq ON public.scphistory USING btree (ledgerseq);
 
 
 --
--- Name: scpquorumsbyseq; Type: INDEX; Schema: public; Owner: -
+-- Name: scpquorumsbyseq; Type: INDEX; Schema: public; Owner: charlie
 --
 
 CREATE INDEX scpquorumsbyseq ON public.scpquorums USING btree (lastledgerseq);
 
 
 --
--- Name: sellingissuerindex; Type: INDEX; Schema: public; Owner: -
+-- Name: sellingissuerindex; Type: INDEX; Schema: public; Owner: charlie
 --
 
 CREATE INDEX sellingissuerindex ON public.offers USING btree (sellingissuer);
 
 
 --
--- Name: signersaccount; Type: INDEX; Schema: public; Owner: -
+-- Name: signersaccount; Type: INDEX; Schema: public; Owner: charlie
 --
 
 CREATE INDEX signersaccount ON public.signers USING btree (accountid);
 
 
 --
--- Name: upgradehistbyseq; Type: INDEX; Schema: public; Owner: -
+-- Name: upgradehistbyseq; Type: INDEX; Schema: public; Owner: charlie
 --
 
 CREATE INDEX upgradehistbyseq ON public.upgradehistory USING btree (ledgerseq);

--- a/tests/unit/model/account_values.test.ts
+++ b/tests/unit/model/account_values.test.ts
@@ -1,6 +1,6 @@
 import stellar from "stellar-base";
 import { AccountValues } from "../../../src/model";
-import { AccountFlagsFactory, AccountThresholdsFactory } from "../../../src/model/factories";
+import { AccountThresholdsFactory } from "../../../src/model/factories";
 import AccountValuesFactory from "../../factories/account_values";
 import SignerFactory from "../../factories/signer";
 
@@ -40,7 +40,6 @@ describe("diffAttrs(other)", () => {
       inflationDestination: "",
       homeDomain: "",
       thresholds: AccountThresholdsFactory.fromValue("AQAAAA=="),
-      flags: AccountFlagsFactory.fromValue(0),
       lastModified: 6,
       signers: []
     };
@@ -52,7 +51,6 @@ describe("diffAttrs(other)", () => {
       inflationDestination: "some_inflation_dest",
       homeDomain: "example.com",
       thresholds: AccountThresholdsFactory.fromValue("AQEBAQ=="),
-      flags: AccountFlagsFactory.fromValue(2),
       lastModified: 5,
       signers: [SignerFactory.build()]
     };
@@ -65,7 +63,6 @@ describe("diffAttrs(other)", () => {
       "numSubentries",
       "inflationDestination",
       "homeDomain",
-      "flags",
       "thresholds",
       "signers"
     ]);

--- a/tests/unit/model/balance.test.ts
+++ b/tests/unit/model/balance.test.ts
@@ -1,4 +1,3 @@
-import { Asset } from "stellar-sdk";
 import { Balance } from "../../../src/model";
 import { BalanceFactory } from "../../../src/model/factories";
 import { MAX_INT64 } from "../../../src/util";
@@ -34,11 +33,7 @@ describe("constructor", () => {
   it("sets limit", () => expect(subject.limit.toString()).toEqual("9223372036854775807"));
   it("sets balance", () => expect(subject.balance.toString()).toEqual("9600000000"));
   it("sets authorized", () => expect(subject.authorized).toBe(true));
-  it("sets asset", () => {
-    expect(subject.asset).toBeInstanceOf(Asset);
-    expect(subject.asset.getCode()).toEqual(data.assetcode);
-    expect(subject.asset.getIssuer()).toEqual(data.issuer);
-  });
+  it("sets asset", () => expect(subject.asset).toEqual(`${data.assetcode}-${data.issuer}`));
   it("sets spendable balance", () => expect(subject.spendableBalance.toString()).toEqual("9599999700"));
   it("sets receivable balance", () => expect(subject.receivableBalance.toString()).toEqual("9223372027254775707"));
 });
@@ -59,6 +54,6 @@ describe("static buildFakeNative(account)", () => {
     expect(fake.spendableBalance.toString()).toEqual("19706072136");
     expect(fake.receivableBalance.toString()).toEqual("9223372017121827946");
 
-    expect(fake.asset.isNative()).toBe(true);
+    expect(fake.asset).toEqual("native");
   });
 });


### PR DESCRIPTION
What we've got here:

* I ditched Horizon regarding assets, and now we're getting assets directly from the database, namely from special postgres view, made by @nebolsin. I expanded it a little, I added flags and appended the row for the native XLM to serve everything consistently
* Now we have the connection to assets from an account, so user now can query all assets, issued by the particular account in a graph-like manner
* thanks to @nebolsin, we now can serve more data about an asset, like holders count and overall tokens number in circulation
* authorization flags now live under assets, not under accounts

More technical notes:

* I dropped `AssetWithInfo` from the schema, we have one type `Asset` now
* I decided to omit native XLM from `query { assets }` response because it breaks alphanumeric sorting in pagination. It happens because we use `"native"` as an id for XLM, which serves as pagination token too, so native XLM won't be between other assets with codes, starting on "X". And it seems not very useful to have it there anyway. If the user would like to obtain some statistics about lumens, they can do it via `query { asset(id: "native") }`
* It would be better to use the `Asset` class from `stellar-sdk` only for parsing XDR, and use our new `Asset` class everywhere else, but I didn't refactor that for now, because it looks like a big deal. Definitely, something to do later

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/astroband/astrograph/159)
<!-- Reviewable:end -->
