### PR TITLE
Cleanup the schema a little

### DIFF
--- a/src/model/effect.ts
+++ b/src/model/effect.ts
@@ -1,7 +1,7 @@
 import { Asset } from "stellar-sdk";
 import { AccountID } from "./";
 
-export enum EffectKinds {
+export enum EffectType {
   AccountCreated = "accountCreated",
   AccountRemoved = "accountRemoved",
   AccountCredited = "accountCredited",
@@ -31,7 +31,7 @@ export enum EffectKinds {
 export interface IBaseEffect {
   id: string;
   account: AccountID;
-  kind: EffectKinds;
+  type: EffectType;
   createdAt: Date;
 }
 

--- a/src/model/factories/effect_factory.ts
+++ b/src/model/factories/effect_factory.ts
@@ -1,5 +1,5 @@
 import { IHorizonEffectData } from "../../datasource/types";
-import { Effect, EffectKinds } from "../effect";
+import { Effect, EffectType } from "../effect";
 import { AssetFactory } from "./asset_factory";
 
 export class EffectFactory {
@@ -7,52 +7,52 @@ export class EffectFactory {
     const baseData = {
       id: data.id,
       account: data.account,
-      kind: data.type.replace(/_([a-z])/g, g => g[1].toUpperCase()) as EffectKinds,
+      type: data.type.replace(/_([a-z])/g, g => g[1].toUpperCase()) as EffectType,
       createdAt: new Date(data.created_at)
     };
 
-    switch (baseData.kind) {
-      case EffectKinds.AccountCreated:
+    switch (baseData.type) {
+      case EffectType.AccountCreated:
         return { ...baseData, startingBalance: data.starting_balance };
-      case EffectKinds.AccountCredited:
-      case EffectKinds.AccountDebited:
+      case EffectType.AccountCredited:
+      case EffectType.AccountDebited:
         return { ...baseData, amount: data.amount };
-      case EffectKinds.AccountThresholdsUpdated:
+      case EffectType.AccountThresholdsUpdated:
         return {
           ...baseData,
           lowThreshold: data.low_threshold,
           medThreshold: data.med_threshold,
           highThreshold: data.high_threshold
         };
-      case EffectKinds.AccountHomeDomainUpdated:
+      case EffectType.AccountHomeDomainUpdated:
         return { ...baseData, homeDomain: data.home_domain };
-      case EffectKinds.AccountFlagsUpdated:
+      case EffectType.AccountFlagsUpdated:
         return { ...baseData, authRequiredFlag: data.auth_required_flag, authRevocableFlag: data.auth_revokable_flag };
-      case EffectKinds.SignerCreated:
-      case EffectKinds.SignerUpdated:
-      case EffectKinds.SignerRemoved:
+      case EffectType.SignerCreated:
+      case EffectType.SignerUpdated:
+      case EffectType.SignerRemoved:
         return {
           ...baseData,
           weight: data.weight,
           publicKey: data.public_key,
           key: data.key
         };
-      case EffectKinds.TrustlineCreated:
-      case EffectKinds.TrustlineUpdated:
-      case EffectKinds.TrustlineRemoved:
+      case EffectType.TrustlineCreated:
+      case EffectType.TrustlineUpdated:
+      case EffectType.TrustlineRemoved:
         return {
           ...baseData,
           asset: AssetFactory.fromHorizon(data.asset_type, data.asset_code, data.asset_issuer),
           limit: data.limit
         };
-      case EffectKinds.TrustlineAuthorized:
-      case EffectKinds.TrustlineDeauthorized:
+      case EffectType.TrustlineAuthorized:
+      case EffectType.TrustlineDeauthorized:
         return {
           ...baseData,
           asset: AssetFactory.fromHorizon(data.asset_type, data.asset_code, data.asset_issuer),
           trustor: data.trustor
         };
-      case EffectKinds.Trade:
+      case EffectType.Trade:
         return {
           ...baseData,
           seller: data.seller,
@@ -66,7 +66,7 @@ export class EffectFactory {
             data.bought_asset_issuer
           )
         };
-      case EffectKinds.SequenceBumped:
+      case EffectType.SequenceBumped:
         return { ...baseData, newSeq: data.new_seq };
       default:
         return baseData;

--- a/src/model/factories/operation_data_mapper/horizon.ts
+++ b/src/model/factories/operation_data_mapper/horizon.ts
@@ -15,7 +15,7 @@ import {
   IPaymentOperation,
   ISetOptionsOperation,
   Operation,
-  OperationKinds
+  OperationType
 } from "../../operation";
 
 export class DataMapper {
@@ -23,30 +23,30 @@ export class DataMapper {
     return new DataMapper(data).call();
   }
 
-  public static mapHorizonOpType(type: HorizonOpType): OperationKinds {
+  public static mapHorizonOpType(type: HorizonOpType): OperationType {
     switch (type) {
       case "create_account":
-        return OperationKinds.CreateAccount;
+        return OperationType.CreateAccount;
       case "payment":
-        return OperationKinds.Payment;
+        return OperationType.Payment;
       case "path_payment":
-        return OperationKinds.PathPayment;
+        return OperationType.PathPayment;
       case "manage_offer":
-        return OperationKinds.ManageOffer;
+        return OperationType.ManageOffer;
       case "create_passive_offer":
-        return OperationKinds.CreatePassiveOffer;
+        return OperationType.CreatePassiveOffer;
       case "set_options":
-        return OperationKinds.SetOption;
+        return OperationType.SetOption;
       case "change_trust":
-        return OperationKinds.ChangeTrust;
+        return OperationType.ChangeTrust;
       case "allow_trust":
-        return OperationKinds.AllowTrust;
+        return OperationType.AllowTrust;
       case "account_merge":
-        return OperationKinds.AccountMerge;
+        return OperationType.AccountMerge;
       case "manage_data":
-        return OperationKinds.ManageData;
+        return OperationType.ManageData;
       case "bump_sequence":
-        return OperationKinds.BumpSequence;
+        return OperationType.BumpSequence;
     }
   }
 
@@ -56,7 +56,7 @@ export class DataMapper {
     this.baseData = {
       id: data.id,
       index: parsePagingToken(data.paging_token).opIndex,
-      kind: DataMapper.mapHorizonOpType(data.type),
+      type: DataMapper.mapHorizonOpType(data.type),
       sourceAccount: data.source_account,
       dateTime: new Date(data.created_at),
       tx: { id: data.transaction_hash }
@@ -64,28 +64,28 @@ export class DataMapper {
   }
 
   public call(): Operation {
-    switch (this.baseData.kind) {
-      case OperationKinds.Payment:
+    switch (this.baseData.type) {
+      case OperationType.Payment:
         return this.mapPayment();
-      case OperationKinds.SetOption:
+      case OperationType.SetOption:
         return this.mapSetOption();
-      case OperationKinds.AccountMerge:
+      case OperationType.AccountMerge:
         return this.mapAccountMerge();
-      case OperationKinds.AllowTrust:
+      case OperationType.AllowTrust:
         return this.mapAllowTrust();
-      case OperationKinds.BumpSequence:
+      case OperationType.BumpSequence:
         return this.mapBumpSequence();
-      case OperationKinds.ChangeTrust:
+      case OperationType.ChangeTrust:
         return this.mapChangeTrust();
-      case OperationKinds.CreateAccount:
+      case OperationType.CreateAccount:
         return this.mapCreateAccount();
-      case OperationKinds.ManageData:
+      case OperationType.ManageData:
         return this.mapManageData();
-      case OperationKinds.ManageOffer:
+      case OperationType.ManageOffer:
         return this.mapManageOffer();
-      case OperationKinds.CreatePassiveOffer:
+      case OperationType.CreatePassiveOffer:
         return this.mapCreatePassiveOffer();
-      case OperationKinds.PathPayment:
+      case OperationType.PathPayment:
         return this.mapPathPayment();
     }
   }

--- a/src/model/operation.ts
+++ b/src/model/operation.ts
@@ -2,7 +2,7 @@ import { Asset } from "stellar-sdk";
 import { HorizonAccountFlag } from "../datasource/types";
 import { AccountID } from "./";
 
-export enum OperationKinds {
+export enum OperationType {
   Payment = "payment",
   SetOption = "setOption",
   AccountMerge = "accountMerge",
@@ -18,7 +18,7 @@ export enum OperationKinds {
 
 export interface IBaseOperation {
   id?: string;
-  kind: OperationKinds;
+  type: OperationType;
   sourceAccount: AccountID;
   tx: { id: string; sourceAccount?: AccountID };
   index: number;

--- a/src/schema/accounts.ts
+++ b/src/schema/accounts.ts
@@ -26,27 +26,8 @@ export const typeDefs = gql`
     high: Int!
   }
 
-  interface IAccount {
-    "Account's [public key](https://www.stellar.org/developers/guides/concepts/accounts.html#account-id)"
-    id: AccountID!
-    "The current transaction sequence number of the account"
-    sequenceNumber: String!
-    "Number of other [entries](https://www.stellar.org/developers/guides/concepts/ledger.html#ledger-entries) the account owns"
-    numSubentries: Int!
-    "Account designated to receive [inflation](https://www.stellar.org/developers/guides/concepts/inflation.html)"
-    inflationDestination: Account
-    "A domain name that can be added to the account. [More info](https://www.stellar.org/developers/guides/concepts/accounts.html#home-domain)"
-    homeDomain: String
-    "Thresholds for different access levels this account set"
-    thresholds: AccountThresholds!
-    "Flags used, by issuers of assets"
-    flags: AccountFlags!
-    "[Signers](https://www.stellar.org/developers/guides/concepts/multi-sig.html) of the account"
-    signers: [Signer]
-  }
-
   "Represents a single [account](https://www.stellar.org/developers/guides/concepts/accounts.html) on Stellar network"
-  type Account implements IAccount {
+  type Account {
     "Account's [public key](https://www.stellar.org/developers/guides/concepts/accounts.html#account-id)"
     id: AccountID!
     "The current transaction sequence number of the account"
@@ -90,7 +71,7 @@ export const typeDefs = gql`
   }
 
   "Represents a current account state, which is broadcasted to subscribers on account's update"
-  type AccountValues implements IAccount {
+  type AccountValues {
     "Account's [public key](https://www.stellar.org/developers/guides/concepts/accounts.html#account-id)"
     id: AccountID!
     "The current transaction sequence number of the account"

--- a/src/schema/effects.ts
+++ b/src/schema/effects.ts
@@ -1,7 +1,7 @@
 import { gql } from "apollo-server";
 
 export const typeDefs = gql`
-  enum EffectKind {
+  enum EffectType {
     accountCreated
     accountRemoved
     accountCredited
@@ -33,14 +33,14 @@ export const typeDefs = gql`
     id: String!
     "Account that this effect changed"
     account: Account!
-    kind: EffectKind!
+    type: EffectType!
     createdAt: DateTime!
   }
 
   type AccountCreatedEffect implements Effect {
     id: String!
     account: Account!
-    kind: EffectKind!
+    type: EffectType!
     createdAt: DateTime!
     "The XLM balance new account was created with"
     startingBalance: String!
@@ -49,14 +49,14 @@ export const typeDefs = gql`
   type AccountRemovedEffect implements Effect {
     id: String!
     account: Account!
-    kind: EffectKind!
+    type: EffectType!
     createdAt: DateTime!
   }
 
   type AccountCreditedEffect implements Effect {
     id: String!
     account: Account!
-    kind: EffectKind!
+    type: EffectType!
     createdAt: DateTime!
     amount: String!
   }
@@ -64,7 +64,7 @@ export const typeDefs = gql`
   type AccountDebitedEffect implements Effect {
     id: String!
     account: Account!
-    kind: EffectKind!
+    type: EffectType!
     createdAt: DateTime!
     amount: String!
   }
@@ -72,7 +72,7 @@ export const typeDefs = gql`
   type AccountThresholdsUpdatedEffect implements Effect {
     id: String!
     account: Account!
-    kind: EffectKind!
+    type: EffectType!
     createdAt: DateTime!
     lowThreshold: Int!
     medThreshold: Int!
@@ -82,7 +82,7 @@ export const typeDefs = gql`
   type AccountHomeDomainUpdatedEffect implements Effect {
     id: String!
     account: Account!
-    kind: EffectKind!
+    type: EffectType!
     createdAt: DateTime!
     homeDomain: String!
   }
@@ -90,7 +90,7 @@ export const typeDefs = gql`
   type AccountFlagsUpdatedEffect implements Effect {
     id: String!
     account: Account!
-    kind: EffectKind!
+    type: EffectType!
     createdAt: DateTime!
     authRequiredFlag: Boolean
     authRevocableFlag: Boolean
@@ -99,14 +99,14 @@ export const typeDefs = gql`
   type AccountInflationDestinationUpdatedEffect implements Effect {
     id: String!
     account: Account!
-    kind: EffectKind!
+    type: EffectType!
     createdAt: DateTime!
   }
 
   type SequenceBumpedEffect implements Effect {
     id: String!
     account: Account!
-    kind: EffectKind!
+    type: EffectType!
     createdAt: DateTime!
     newSeq: Int!
   }
@@ -114,7 +114,7 @@ export const typeDefs = gql`
   type SignerCreatedEffect implements Effect {
     id: String!
     account: Account!
-    kind: EffectKind!
+    type: EffectType!
     createdAt: DateTime!
     weight: Int!
     publicKey: AccountID!
@@ -124,7 +124,7 @@ export const typeDefs = gql`
   type SignerRemovedEffect implements Effect {
     id: String!
     account: Account!
-    kind: EffectKind!
+    type: EffectType!
     createdAt: DateTime!
     weight: Int!
     publicKey: AccountID!
@@ -134,7 +134,7 @@ export const typeDefs = gql`
   type SignerUpdatedEffect implements Effect {
     id: String!
     account: Account!
-    kind: EffectKind!
+    type: EffectType!
     createdAt: DateTime!
     weight: Int!
     publicKey: AccountID!
@@ -144,7 +144,7 @@ export const typeDefs = gql`
   type TrustlineCreatedEffect implements Effect {
     id: String!
     account: Account!
-    kind: EffectKind!
+    type: EffectType!
     createdAt: DateTime!
     asset: Asset!
     limit: String!
@@ -153,7 +153,7 @@ export const typeDefs = gql`
   type TrustlineRemovedEffect implements Effect {
     id: String!
     account: Account!
-    kind: EffectKind!
+    type: EffectType!
     createdAt: DateTime!
     asset: Asset!
     limit: String!
@@ -162,7 +162,7 @@ export const typeDefs = gql`
   type TrustlineUpdatedEffect implements Effect {
     id: String!
     account: Account!
-    kind: EffectKind!
+    type: EffectType!
     createdAt: DateTime!
     asset: Asset!
     limit: String!
@@ -171,7 +171,7 @@ export const typeDefs = gql`
   type TrustlineAuthorizedEffect implements Effect {
     id: String!
     account: Account!
-    kind: EffectKind!
+    type: EffectType!
     createdAt: DateTime!
     trustor: AccountID!
     asset: Asset!
@@ -180,7 +180,7 @@ export const typeDefs = gql`
   type TrustlineDeauthorizedEffect implements Effect {
     id: String!
     account: Account!
-    kind: EffectKind!
+    type: EffectType!
     createdAt: DateTime!
     trustor: AccountID!
     asset: Asset!
@@ -189,28 +189,28 @@ export const typeDefs = gql`
   type OfferCreatedEffect implements Effect {
     id: String!
     account: Account!
-    kind: EffectKind!
+    type: EffectType!
     createdAt: DateTime!
   }
 
   type OfferRemovedEffect implements Effect {
     id: String!
     account: Account!
-    kind: EffectKind!
+    type: EffectType!
     createdAt: DateTime!
   }
 
   type OfferUpdatedEffect implements Effect {
     id: String!
     account: Account!
-    kind: EffectKind!
+    type: EffectType!
     createdAt: DateTime!
   }
 
   type TradeEffect implements Effect {
     id: String!
     account: Account!
-    kind: EffectKind!
+    type: EffectType!
     createdAt: DateTime!
     seller: AccountID!
     offerId: OfferID!
@@ -223,21 +223,21 @@ export const typeDefs = gql`
   type DataCreatedEffect implements Effect {
     id: String!
     account: Account!
-    kind: EffectKind!
+    type: EffectType!
     createdAt: DateTime!
   }
 
   type DataUpdatedEffect implements Effect {
     id: String!
     account: Account!
-    kind: EffectKind!
+    type: EffectType!
     createdAt: DateTime!
   }
 
   type DataRemovedEffect implements Effect {
     id: String!
     account: Account!
-    kind: EffectKind!
+    type: EffectType!
     createdAt: DateTime!
   }
 

--- a/src/schema/offers.ts
+++ b/src/schema/offers.ts
@@ -3,23 +3,7 @@ import { gql } from "apollo-server";
 export const typeDefs = gql`
   scalar OfferID
 
-  interface IOffer {
-    id: OfferID!
-    "Account created this offer"
-    seller: Account!
-    "Asset seller is selling"
-    selling: Asset!
-    "Asset seller wants to buy"
-    buying: Asset!
-    "Amount of \`selling\` being sold"
-    amount: Float!
-    "Price of 1 unit of \`selling\` in terms of \`buying\`"
-    price: String!
-    "Is this offer [passive](https://www.stellar.org/developers/guides/concepts/list-of-operations.html#create-passive-offer)"
-    passive: Boolean!
-  }
-
-  type Offer implements IOffer {
+  type Offer {
     id: OfferID!
     seller: Account!
     selling: Asset!
@@ -33,7 +17,7 @@ export const typeDefs = gql`
   }
 
   "Represents a current offer state, which is broadcasted to subscribers"
-  type OfferValues implements IOffer {
+  type OfferValues {
     id: OfferID!
     seller: Account!
     selling: Asset!

--- a/src/schema/operations.ts
+++ b/src/schema/operations.ts
@@ -1,7 +1,7 @@
 import { gql } from "apollo-server";
 
 export const typeDefs = gql`
-  enum OperationKind {
+  enum OperationType {
     payment
     setOption
     accountMerge
@@ -19,7 +19,7 @@ export const typeDefs = gql`
   interface Operation {
     "Operation id, assigned by Horizon"
     id: String!
-    kind: OperationKind!
+    type: OperationType!
     "Account on which behalf operation was executed"
     sourceAccount: Account!
     "When operations was executed"
@@ -32,7 +32,7 @@ export const typeDefs = gql`
   type PaymentOperation implements Operation {
     "Operation id, assigned by Horizon"
     id: String!
-    kind: OperationKind!
+    type: OperationType!
     "Account on which behalf operation was executed"
     sourceAccount: Account!
     "When operations was executed"
@@ -51,7 +51,7 @@ export const typeDefs = gql`
   type SetOptionsOperation implements Operation {
     "Operation id, assigned by Horizon"
     id: String!
-    kind: OperationKind!
+    type: OperationType!
     "Account on which behalf operation was executed"
     sourceAccount: Account!
     "When operations was executed"
@@ -78,7 +78,7 @@ export const typeDefs = gql`
   type AccountMergeOperation implements Operation {
     "Operation id, assigned by Horizon"
     id: String!
-    kind: OperationKind!
+    type: OperationType!
     "Account on which behalf operation was executed"
     sourceAccount: Account!
     "When operations was executed"
@@ -93,7 +93,7 @@ export const typeDefs = gql`
   type AllowTrustOperation implements Operation {
     "Operation id, assigned by Horizon"
     id: String!
-    kind: OperationKind!
+    type: OperationType!
     "Account on which behalf operation was executed"
     sourceAccount: Account!
     "When operations was executed"
@@ -112,7 +112,7 @@ export const typeDefs = gql`
   type BumpSequenceOperation implements Operation {
     "Operation id, assigned by Horizon"
     id: String!
-    kind: OperationKind!
+    type: OperationType!
     "Account on which behalf operation was executed"
     sourceAccount: Account!
     "When operations was executed"
@@ -127,7 +127,7 @@ export const typeDefs = gql`
   type ChangeTrustOperation implements Operation {
     "Operation id, assigned by Horizon"
     id: String!
-    kind: OperationKind!
+    type: OperationType!
     "Account on which behalf operation was executed"
     sourceAccount: Account!
     "When operations was executed"
@@ -144,7 +144,7 @@ export const typeDefs = gql`
   type CreateAccountOperation implements Operation {
     "Operation id, assigned by Horizon"
     id: String!
-    kind: OperationKind!
+    type: OperationType!
     "Account on which behalf operation was executed"
     sourceAccount: Account!
     "When operations was executed"
@@ -161,7 +161,7 @@ export const typeDefs = gql`
   type ManageDatumOperation implements Operation {
     "Operation id, assigned by Horizon"
     id: String!
-    kind: OperationKind!
+    type: OperationType!
     "Account on which behalf operation was executed"
     sourceAccount: Account!
     "When operations was executed"
@@ -176,7 +176,7 @@ export const typeDefs = gql`
   type ManageOfferOperation implements Operation {
     "Operation id, assigned by Horizon"
     id: String!
-    kind: OperationKind!
+    type: OperationType!
     "Account on which behalf operation was executed"
     sourceAccount: Account!
     "When operations was executed"
@@ -200,7 +200,7 @@ export const typeDefs = gql`
   type CreatePassiveOfferOperation implements Operation {
     "Operation id, assigned by Horizon"
     id: String!
-    kind: OperationKind!
+    type: OperationType!
     "Account on which behalf operation was executed"
     sourceAccount: Account!
     "When operations was executed"
@@ -218,7 +218,7 @@ export const typeDefs = gql`
   type PathPaymentOperation implements Operation {
     "Operation id, assigned by Horizon"
     id: String!
-    kind: OperationKind!
+    type: OperationType!
     "Account on which behalf operation was executed"
     sourceAccount: Account!
     "When operations was executed"
@@ -284,7 +284,7 @@ export const typeDefs = gql`
     operations(
       txSource: [AccountID]
       opSource: [AccountID]
-      kind: [OperationKind]
+      type: [OperationType]
       destination: [AccountID]
       asset: [AssetID]
     ): Operation!

--- a/src/schema/resolvers/data_entry.ts
+++ b/src/schema/resolvers/data_entry.ts
@@ -21,10 +21,7 @@ const dataEntrySubscription = (event: string) => {
 };
 
 export default {
-  DataEntry: {
-    account: resolvers.account,
-    ledger: resolvers.ledger
-  },
+  DataEntry: { ledger: resolvers.ledger },
   DataEntryValues: {
     account: resolvers.account,
     ledger: resolvers.ledger

--- a/src/schema/resolvers/data_entry.ts
+++ b/src/schema/resolvers/data_entry.ts
@@ -21,8 +21,14 @@ const dataEntrySubscription = (event: string) => {
 };
 
 export default {
-  IDataEntry: { ledger: resolvers.ledger },
-  DataEntryValues: { account: resolvers.account },
+  DataEntry: {
+    account: resolvers.account,
+    ledger: resolvers.ledger
+  },
+  DataEntryValues: {
+    account: resolvers.account,
+    ledger: resolvers.ledger
+  },
   DataEntrySubscriptionPayload: { account: resolvers.account },
   Subscription: {
     dataEntry: dataEntrySubscription(DATA_ENTRY)

--- a/src/schema/resolvers/effect.ts
+++ b/src/schema/resolvers/effect.ts
@@ -1,6 +1,6 @@
 import { IHorizonEffectData } from "../../datasource/types";
 import { IApolloContext } from "../../graphql_server";
-import { Effect, EffectKinds } from "../../model";
+import { Effect, EffectType } from "../../model";
 import { EffectFactory } from "../../model/factories";
 import * as resolvers from "./shared";
 import { makeConnection } from "./util";
@@ -8,54 +8,54 @@ import { makeConnection } from "./util";
 export default {
   Effect: {
     __resolveType(effect: Effect) {
-      switch (effect.kind) {
-        case EffectKinds.AccountCreated:
+      switch (effect.type) {
+        case EffectType.AccountCreated:
           return "AccountCreatedEffect";
-        case EffectKinds.AccountRemoved:
+        case EffectType.AccountRemoved:
           return "AccountRemovedEffect";
-        case EffectKinds.AccountCredited:
+        case EffectType.AccountCredited:
           return "AccountCreditedEffect";
-        case EffectKinds.AccountDebited:
+        case EffectType.AccountDebited:
           return "AccountDebitedEffect";
-        case EffectKinds.AccountThresholdsUpdated:
+        case EffectType.AccountThresholdsUpdated:
           return "AccountThresholdsUpdatedEffect";
-        case EffectKinds.AccountHomeDomainUpdated:
+        case EffectType.AccountHomeDomainUpdated:
           return "AccountHomeDomainUpdatedEffect";
-        case EffectKinds.AccountFlagsUpdated:
+        case EffectType.AccountFlagsUpdated:
           return "AccountFlagsUpdatedEffect";
-        case EffectKinds.AccountInflationDestinationUpdated:
+        case EffectType.AccountInflationDestinationUpdated:
           return "AccountInflationDestinationUpdatedEffect";
-        case EffectKinds.SignerCreated:
+        case EffectType.SignerCreated:
           return "SignerCreatedEffect";
-        case EffectKinds.SignerRemoved:
+        case EffectType.SignerRemoved:
           return "SignerRemovedEffect";
-        case EffectKinds.SignerUpdated:
+        case EffectType.SignerUpdated:
           return "SignerUpdatedEffect";
-        case EffectKinds.TrustlineCreated:
+        case EffectType.TrustlineCreated:
           return "TrustlineCreatedEffect";
-        case EffectKinds.TrustlineRemoved:
+        case EffectType.TrustlineRemoved:
           return "TrustlineRemovedEffect";
-        case EffectKinds.TrustlineUpdated:
+        case EffectType.TrustlineUpdated:
           return "TrustlineUpdatedEffect";
-        case EffectKinds.TrustlineAuthorized:
+        case EffectType.TrustlineAuthorized:
           return "TrustlineAuthorizedEffect";
-        case EffectKinds.TrustlineDeauthorized:
+        case EffectType.TrustlineDeauthorized:
           return "TrustlineDeauthorizedEffect";
-        case EffectKinds.OfferCreated:
+        case EffectType.OfferCreated:
           return "OfferCreatedEffect";
-        case EffectKinds.OfferRemoved:
+        case EffectType.OfferRemoved:
           return "OfferRemovedEffect";
-        case EffectKinds.OfferUpdated:
+        case EffectType.OfferUpdated:
           return "OfferUpdatedEffect";
-        case EffectKinds.Trade:
+        case EffectType.Trade:
           return "TradeEffect";
-        case EffectKinds.DataCreated:
+        case EffectType.DataCreated:
           return "DataCreatedEffect";
-        case EffectKinds.DataRemoved:
+        case EffectType.DataRemoved:
           return "DataRemovedEffect";
-        case EffectKinds.DataUpdated:
+        case EffectType.DataUpdated:
           return "DataUpdatedEffect";
-        case EffectKinds.SequenceBumped:
+        case EffectType.SequenceBumped:
           return "SequenceBumpedEffect";
         default:
           return null;

--- a/src/schema/resolvers/operation.ts
+++ b/src/schema/resolvers/operation.ts
@@ -2,7 +2,7 @@ import { withFilter } from "graphql-subscriptions";
 import { Asset } from "stellar-base";
 import { IHorizonOperationData } from "../../datasource/types";
 import { IApolloContext } from "../../graphql_server";
-import { Operation, OperationKinds, Transaction } from "../../model";
+import { Operation, OperationType, Transaction } from "../../model";
 import { OperationFactory, TransactionWithXDRFactory } from "../../model/factories";
 import { NEW_OPERATION, pubsub } from "../../pubsub";
 import { makeConnection } from "./util";
@@ -21,28 +21,28 @@ export default {
       return TransactionWithXDRFactory.fromHorizon(records[0]);
     },
     __resolveType(operation: Operation) {
-      switch (operation.kind) {
-        case OperationKinds.Payment:
+      switch (operation.type) {
+        case OperationType.Payment:
           return "PaymentOperation";
-        case OperationKinds.SetOption:
+        case OperationType.SetOption:
           return "SetOptionsOperation";
-        case OperationKinds.AccountMerge:
+        case OperationType.AccountMerge:
           return "AccountMergeOperation";
-        case OperationKinds.AllowTrust:
+        case OperationType.AllowTrust:
           return "AllowTrustOperation";
-        case OperationKinds.BumpSequence:
+        case OperationType.BumpSequence:
           return "BumpSequenceOperation";
-        case OperationKinds.ChangeTrust:
+        case OperationType.ChangeTrust:
           return "ChangeTrustOperation";
-        case OperationKinds.CreateAccount:
+        case OperationType.CreateAccount:
           return "CreateAccountOperation";
-        case OperationKinds.ManageData:
+        case OperationType.ManageData:
           return "ManageDatumOperation";
-        case OperationKinds.ManageOffer:
+        case OperationType.ManageOffer:
           return "ManageOfferOperation";
-        case OperationKinds.CreatePassiveOffer:
+        case OperationType.CreatePassiveOffer:
           return "CreatePassiveOfferOperation";
-        case OperationKinds.PathPayment:
+        case OperationType.PathPayment:
           return "PathPaymentOperation";
       }
 
@@ -85,7 +85,7 @@ export default {
             return false;
           }
 
-          if (vars.kind && !vars.kind.includes(payload.kind)) {
+          if (vars.type && !vars.type.includes(payload.type)) {
             return false;
           }
 

--- a/src/schema/type_defs.ts
+++ b/src/schema/type_defs.ts
@@ -25,14 +25,8 @@ export const typeDefs = gql`
     REMOVE
   }
 
-  interface IDataEntry {
-    name: String!
-    value: String!
-    ledger: Ledger!
-  }
-
   "Represents a [Data Entry](https://www.stellar.org/developers/guides/concepts/list-of-operations.html#manage-data) (name/value pair) that is attached to a particular account"
-  type DataEntry implements IDataEntry {
+  type DataEntry {
     name: String!
     value: String!
     "Ledger sequence this data entry was created at"
@@ -40,7 +34,7 @@ export const typeDefs = gql`
   }
 
   "Represents a current [Data Entry](https://www.stellar.org/developers/guides/concepts/list-of-operations.html#manage-data) (name/value pair) state, which is broadcasted to subscribers"
-  type DataEntryValues implements IDataEntry {
+  type DataEntryValues {
     account: Account!
     name: String!
     value: String!
@@ -55,15 +49,8 @@ export const typeDefs = gql`
     values: DataEntryValues
   }
 
-  interface IBalance {
-    asset: Asset!
-    limit: String!
-    balance: String!
-    authorized: Boolean!
-  }
-
   "Represents a single [trustline](https://www.stellar.org/developers/guides/concepts/assets.html#trustlines) of a particular account"
-  type Balance implements IBalance {
+  type Balance {
     account: Account
     asset: Asset!
     limit: String!
@@ -88,7 +75,7 @@ export const typeDefs = gql`
   }
 
   "Represents a current [trustline](https://www.stellar.org/developers/guides/concepts/assets.html#trustlines) state, which is broadcasting to subscribers"
-  type BalanceValues implements IBalance {
+  type BalanceValues {
     account: Account
     asset: Asset!
     limit: String!

--- a/src/util/extract_operation.ts
+++ b/src/util/extract_operation.ts
@@ -1,7 +1,7 @@
 import BigNumber from "bignumber.js";
 import { Asset } from "stellar-base";
 import { ChangesExtractor, ChangeType, EntryType } from "../changes_extractor";
-import { AccountID, Operation, OperationKinds, Transaction, TransactionWithXDR } from "../model";
+import { AccountID, Operation, OperationType, Transaction, TransactionWithXDR } from "../model";
 import { publicKeyFromXDR } from "./xdr/account";
 import { refineOperationXDR } from "./xdr_refiner";
 
@@ -15,11 +15,11 @@ export default function extractOperation(tx: TransactionWithXDR, index: number):
   const opObject = refineOperationXDR(opXDR);
   const opSource = opObject.source || tx.sourceAccount;
 
-  if (opObject.kind === OperationKinds.AllowTrust) {
+  if (opObject.kind === OperationType.AllowTrust) {
     opObject.asset = new Asset(opObject.asset, opSource);
   }
 
-  if (opObject.kind === OperationKinds.PathPayment && tx.success) {
+  if (opObject.kind === OperationType.PathPayment && tx.success) {
     opObject.amountSent = getSentAmount(tx, index, opSource);
   }
 


### PR DESCRIPTION
Making our GraphQL schema more consistent. I removed seemingly unnecessary interfaces, and no more _kind/type_ suffixes in enums, only _type_ now

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/astroband/astrograph/167)
<!-- Reviewable:end -->
