### PR TITLE
Use integer offer price parts

### DIFF
--- a/src/service/dex/offers_graph.ts
+++ b/src/service/dex/offers_graph.ts
@@ -13,22 +13,46 @@ interface IEdge {
   data: IEdgeData;
 }
 
-interface IAssetOrder {
-  amount: BigNumber;
-  price: BigNumber;
-  priceN: number;
-  priceD: number;
+class AssetOrder {
+  public readonly amount: BigNumber;
+  public readonly price: BigNumber; // we use it just for sorting
+  public readonly priceN: number;
+  public readonly priceD: number;
+
+  constructor(offer: Offer) {
+    this.amount = offer.amount;
+    this.price = offer.price;
+    this.priceD = offer.priceD;
+    this.priceN = offer.priceN;
+  }
+
+  public get sellingBound() {
+    const { amount, priceN, priceD } = this;
+    let sellingBound = amount;
+
+    if (priceN <= priceD) {
+      sellingBound = amount
+        .times(priceN)
+        .div(priceD)
+        .integerValue(BigNumber.ROUND_FLOOR)
+        .times(priceD)
+        .div(priceN)
+        .integerValue(BigNumber.ROUND_CEIL);
+    }
+
+    return sellingBound;
+  }
 }
 
 class AssetOrders {
-  constructor(private readonly orders: IAssetOrder[] = []) {}
+  constructor(private readonly orders: AssetOrder[] = []) {}
 
   public getOrders() {
     // return copy of the orders
     return this.orders.map(o => o);
   }
 
-  public addOrder(order: IAssetOrder): void {
+  public addOrder(order: AssetOrder): void {
     this.orders.push(order);
   }
 
@@ -39,7 +63,10 @@ class AssetOrders {
   public buy(amountToBuy: BigNumber): BigNumber {
     let amountToSell = new BigNumber(0);
 
-    for (const { amount, priceN, priceD } of this.orders) {
+    for (const order of this.orders) {
+      const amount = order.sellingBound;
+      const { priceN, priceD } = order;
+
       if (amountToBuy.gt(amount)) {
         amountToSell = amountToSell.plus(amount.times(priceN).div(priceD));
         amountToBuy = amountToBuy.minus(amount);
@@ -49,7 +76,7 @@ class AssetOrders {
       }
     }
 
-    return amountToSell.integerValue(BigNumber.ROUND_FLOOR);
+    return amountToSell;
   }
 }
 
@@ -72,12 +99,7 @@ export class OffersGraph {
       const [assetToBuy, assetToSell] = [offer.buying, offer.selling];
 
       const edge = this.getEdgeData(assetToSell, assetToBuy);
-      const order: IAssetOrder = {
-        amount: offer.amount,
-        price: offer.price,
-        priceN: offer.priceN,
-        priceD: offer.priceD
-      };
+      const order = new AssetOrder(offer);
 
       if (!edge) {
         this.addEdge(assetToSell, assetToBuy, {
@@ -106,9 +128,9 @@ export class OffersGraph {
     let capacity = new BigNumber(0);
     const orderBook = new AssetOrders();
 
-    for (const { amount, price, priceN, priceD } of offers) {
-      orderBook.addOrder({ amount, price, priceN, priceD });
-      capacity = capacity.plus(amount);
+    for (const offer of offers) {
+      orderBook.addOrder(new AssetOrder(offer));
+      capacity = capacity.plus(offer.amount);
     }
 
     this.updateEdge(selling, buying, { capacity, orderBook });


### PR DESCRIPTION
This PR is an attempt to fix #180 

At the moment, it's just quick and dirty approach:

it uses `pricen` and `priced` offer attributes, instead of float `price`. Also, it rounds down amount to buy

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/astroband/astrograph/181)
<!-- Reviewable:end -->
