### PR TITLE
Calculate `amountReceived` for `pathPaymentStrictSend`

### DIFF
--- a/src/datasource/horizon/index.ts
+++ b/src/datasource/horizon/index.ts
@@ -1,3 +1,4 @@
+export * from "./base";
 export * from "./operations";
 export * from "./payments";
 export * from "./trades";

--- a/src/schema/operations.ts
+++ b/src/schema/operations.ts
@@ -254,10 +254,10 @@ export const typeDefs = gql`
     transaction: Transaction!
     "Max send amount"
     sendMax: String!
-    "Amount of \`sourceAsset\` sent by the source account"
-    amountSent: String!
-    "Amount of \`destinationAsset\` received by the destination account"
-    amountReceived: String!
+    "Amount of \`sourceAsset\` sent by the source account. Can be empty for the failed transaction"
+    amountSent: String
+    "Amount of \`destinationAsset\` received by the destination account. Can be empty for the failed transaction"
+    amountReceived: String
     "What asset sender wants receiver to receive in the end"
     destinationAsset: Asset!
     "What asset sender wants to send"
@@ -289,12 +289,12 @@ export const typeDefs = gql`
     dateTime: DateTime!
     "Transaction that contains this operation"
     transaction: Transaction!
-    "Minimum amount of \`destinationAsset\` receiver will get"
+    "Minimum amount of \`destinationAsset\` receiver will get. Can be empty for the failed transaction"
     destinationMin: String!
-    "Amount of \`sourceAsset\` sent by the source account"
-    amountSent: String!
+    "Amount of \`sourceAsset\` sent by the source account. Can be empty for the failed transaction"
+    amountSent: String
     "Amount of \`destinationAsset\` received by the destination account"
-    amountReceived: String!
+    amountReceived: String
     "What asset sender wants receiver to receive in the end"
     destinationAsset: Asset!
     "What asset sender wants to send"

--- a/src/util/xdr_refiner.ts
+++ b/src/util/xdr_refiner.ts
@@ -120,7 +120,7 @@ function refinePathPaymentOpXDR(body: any) {
 function refinePathPaymentStrictSendOpXDR(body: any) {
   return {
     destinationMin: body.destMin().toString(),
-    amountReceived: body.destAmount().toString(),
+    amountSent: body.sendAmount().toString(),
     destinationAccount: publicKeyFromBuffer(body.destination().value()),
     destinationAsset: Asset.fromOperation(body.destAsset()),
     sourceAsset: Asset.fromOperation(body.sendAsset())


### PR DESCRIPTION
We should calculate `amountReceived` for the `pathPaymentStrictSend` operations, just like we calculate `amountSent` for the good old path payments. Also, I relaxed "not null" requirements for this fields, because they can be empty for failed transactions

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/astroband/astrograph/184)
<!-- Reviewable:end -->
